### PR TITLE
Fix potential double fclose on file stream.

### DIFF
--- a/image/image-pnm.cpp
+++ b/image/image-pnm.cpp
@@ -26,10 +26,12 @@ bool image_load_pnm(const char *filename, Image& image)
     if ( (!strncmp(buf, "P4\n", 3)) ) type=4;
     if ( (!strncmp(buf, "P5\n", 3)) ) type=5;
     if ( (!strncmp(buf, "P6\n", 3)) ) type=6;
-    if ( (!strncmp(buf, "P7\n", 3)) ) {fclose(fp); image_load_pam(filename, image);}
+    if ( (!strncmp(buf, "P7\n", 3)) ) {fclose(fp); fp=NULL; image_load_pam(filename, image);}
     if (type==0) {
         e_printf("PNM file is not of type P4, P5 or P6, cannot read other types.\n");
-        fclose(fp);
+        if (fp) {
+            fclose(fp);
+        }
         return false;
     }
     do {


### PR DESCRIPTION
If the image is of type "P7", then "type" is never changed from the "0" it is initialized to.
That means that the file would be closed twice, so once the file is closed, set the handle to NULL and prevent closing a NULL pointer.