### PR TITLE
Abstract out end of stream

### DIFF
--- a/fileio.hpp
+++ b/fileio.hpp
@@ -16,6 +16,8 @@ private:
 	FileIO(FileIO&&) {}
 	void operator=(FileIO&&) {}
 public:
+    const int EOS = -1;
+
     FileIO(FILE* fil, const char *aname) : file(fil), name(aname) { }
     ~FileIO() {
         if (file) fclose(file);
@@ -59,6 +61,8 @@ private:
     size_t data_array_size;
     size_t seek_pos;
 public:
+    const int EOS = -1;
+
     BlobReader(const uint8_t* _data, size_t _data_array_size)
     : data(_data)
     , data_array_size(_data_array_size)
@@ -74,7 +78,7 @@ public:
     }
     int getc() {
         if(seek_pos >= data_array_size)
-            return EOF;
+            return EOS;
         return data[seek_pos++];
     }
     char * gets(char *buf, int n) {
@@ -91,7 +95,7 @@ public:
     }
     int fputc(int c) {
       // cannot write on const memory
-      return EOF;
+      return EOS;
     }
     void fseek(long offset, int where) {
         switch(where) {
@@ -148,6 +152,8 @@ private:
         std::swap(data_array_size, new_size);
     }
 public:
+    const int EOS = -1;
+
     BlobIO()
     : data(0)
     , data_array_size(0)
@@ -183,7 +189,7 @@ public:
     }
     int getc() {
         if(seek_pos >= bytes_used)
-            return EOF;
+            return EOS;
         return data[seek_pos++];
     }
     char * gets(char *buf, int n) {

--- a/maniac/rac.hpp
+++ b/maniac/rac.hpp
@@ -62,7 +62,7 @@ private:
     int read_catch_eof()
     {
         int c = io.getc();
-        if(c == EOF)
+        if(c == io.EOS)
             return 0;
         return c;
     }


### PR DESCRIPTION
Using EOF brings in the `stdio` dependency, which affects the emscripten port.