### PR TITLE
Initialize ColorBuckets to NULL in TransformCB to prevent delete of uninitialized pointer.

### DIFF
--- a/transform/colorbuckets.hpp
+++ b/transform/colorbuckets.hpp
@@ -283,7 +283,7 @@ class TransformCB : public Transform<IO> {
 protected:
     ColorBuckets *cb;
     bool really_used;
-
+    
     ~TransformCB() {if (!really_used) delete cb;}
     bool undo_redo_during_decode() { return false; }
 
@@ -319,6 +319,7 @@ protected:
         return new ColorRangesCB(srcRanges, cb);
     }
     bool init(const ColorRanges *srcRanges) {
+        cb = NULL;
         really_used = false;
         if(srcRanges->numPlanes() < 3) return false;
         if (srcRanges->min(0) == 0 && srcRanges->max(0) == 0 && srcRanges->min(2) == 0 && srcRanges->max(2) == 0) return false; // probably palette image


### PR DESCRIPTION
FLIF encoder crashes with greyscale PNG input. I found the cause to be that `delete cb` is called without `cb` ever being initialized or created.


![test image](https://cloud.githubusercontent.com/assets/395851/10926758/393ccc28-8268-11e5-9303-d4fe928d6527.png) Above test image should crash the encoder without the included commit.