### PR TITLE
New stats for bit chances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(IMAGE_SOURCES
 
 set(MANIAC_SOURCES
     maniac/chance.cpp
+    maniac/symbol.cpp
 )
 
 set(TRANSFORM_SOURCES

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,15 @@ LDFLAGS := $(shell pkg-config --libs zlib libpng)
 export LD_LIBRARY_PATH=$(shell pwd):$LD_LIBRARY_PATH
 
 FILES_H := maniac/*.hpp maniac/*.cpp image/*.hpp transform/*.hpp flif-enc.hpp flif-dec.hpp common.hpp flif_config.h fileio.hpp io.hpp io.cpp config.h
-FILES_CPP := maniac/chance.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/image-rggb.cpp image/color_range.cpp transform/factory.cpp common.cpp flif-enc.cpp flif-dec.cpp io.cpp
+FILES_CPP := maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/image-rggb.cpp image/color_range.cpp transform/factory.cpp common.cpp flif-enc.cpp flif-dec.cpp io.cpp
 
 all: flif libflif.so viewflif
 
 flif: $(FILES_H) $(FILES_CPP) flif.cpp
 	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall $(FILES_CPP) flif.cpp -o flif $(LDFLAGS)
+
+flif.stats: $(FILES_H) $(FILES_CPP) flif.cpp
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DSTATS -DNDEBUG -O3 -g0 -Wall $(FILES_CPP) flif.cpp -o flif.stats $(LDFLAGS)
 
 flif.prof: $(FILES_H) $(FILES_CPP) flif.cpp
 	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -pg -Wall $(FILES_CPP) flif.cpp -o flif.prof $(LDFLAGS)

--- a/flif-dec.cpp
+++ b/flif-dec.cpp
@@ -414,7 +414,7 @@ bool flif_decode(IO& io, Images &images, int quality, int scale, uint32_t (*call
     v_printf(4,"Transforms: ");
     int tcount=0;
     transform_l=0;
-    while (rac.read()) {
+    while (rac.read_bit()) {
         if (transform_l > MAX_TRANSFORM) return false;
         std::string desc = read_name(rac);
         Transform<IO> *trans = create_transform<IO>(desc);

--- a/flif-enc.cpp
+++ b/flif-enc.cpp
@@ -89,13 +89,6 @@ void flif_encode_scanlines_pass(Rac &rac, const Images &images, const ColorRange
     for (int p = 0; p < ranges->numPlanes(); p++) {
         coders[p].simplify(divisor, min_size);
     }
-
-    for (int p = 0; p < ranges->numPlanes(); p++) {
-#ifdef STATS
-        indent(0); v_printf(2,"Plane %i\n", p);
-        coders[p].info(0+1);
-#endif
-    }
 }
 
 template<typename Rac, typename Coder> void flif_encode_FLIF2_inner(Rac rac, std::vector<Coder> &coders, const Images &images, const ColorRanges *ranges, const int beginZL, const int endZL)
@@ -188,13 +181,6 @@ void flif_encode_FLIF2_pass(Rac &rac, const Images &images, const ColorRanges *r
     }
     for (int p = 0; p < images[0].numPlanes(); p++) {
         coders[p].simplify(divisor, min_size);
-    }
-
-    for (int p = 0; p < images[0].numPlanes(); p++) {
-#ifdef STATS
-        indent(0); v_printf(2,"Plane %i\n", p);
-        coders[p].info(0+1);
-#endif
     }
 }
 

--- a/flif-enc.cpp
+++ b/flif-enc.cpp
@@ -358,7 +358,7 @@ bool flif_encode(IO& io, Images &images, std::vector<std::string> transDesc, fli
             if (tcount++ > 0) v_printf(4,", ");
             v_printf(4,"%s", transDesc[i].c_str());
             fflush(stdout);
-            rac.write(true);
+            rac.write_bit(true);
             write_name(rac, transDesc[i]);
             trans->save(rangesList.back(), rac);
             fflush(stdout);
@@ -368,7 +368,7 @@ bool flif_encode(IO& io, Images &images, std::vector<std::string> transDesc, fli
         delete trans;
     }
     if (tcount==0) v_printf(4,"none\n"); else v_printf(4,"\n");
-    rac.write(false);
+    rac.write_bit(false);
     const ColorRanges* ranges = rangesList.back();
     grey.clear();
     for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);

--- a/flif_config.h
+++ b/flif_config.h
@@ -5,14 +5,14 @@
 #include "fileio.hpp"
 
 #ifdef FAST_BUT_WORSE_COMPRESSION
-template <typename IO> using RacIn = RacInput20<IO>;
+template <typename IO> using RacIn = RacInput24<IO>;
 #else
 template <typename IO> using RacIn = RacInput40<IO>;
 #endif
 
 #ifdef HAS_ENCODER
 #ifdef FAST_BUT_WORSE_COMPRESSION
-template <typename IO> using RacOut = RacOutput20<IO>;
+template <typename IO> using RacOut = RacOutput24<IO>;
 #else
 template <typename IO> using RacOut = RacOutput40<IO>;
 #endif

--- a/maniac/chance.hpp
+++ b/maniac/chance.hpp
@@ -18,49 +18,12 @@ struct Log4kTable {
 
 extern const Log4kTable log4k;
 
-class StaticBitChanceTable
-{
-public:
-    StaticBitChanceTable() {};
-};
-
-class StaticBitChance
-{
-protected:
-    uint16_t chance; // stored as a 16-bit number
-
-public:
-    typedef StaticBitChanceTable Table;
-
-    StaticBitChance(int chanceIn = 0x800) {
-        chance = chanceIn;
-    }
-
-    uint16_t inline get() const {
-        return chance; // * 16; // return 16-bit number
-    }
-
-    void set(uint16_t chanceIn) {
-        chance = chanceIn;
-    }
-
-    void inline put(bool, const Table &) {}
-
-    void estim(bool bit, uint64_t &total) const {
-        total += log4k.data[bit ? chance : 4096-chance];
-    }
-
-    int scale() const {
-        return log4k.scale;
-    }
-};
-
 void extern build_table(uint16_t *zero_state, uint16_t *one_state, size_t size, int factor, unsigned int max_p);
 
 class SimpleBitChanceTable
 {
 public:
-    uint16_t next[2][4096];
+    uint16_t next[2][4096]; // stored as 12-bit numbers
 
     void init(int cut, int alpha) {
         build_table(next[0], next[1], 4096, alpha, 4096-cut);
@@ -79,14 +42,14 @@ protected:
 public:
     typedef SimpleBitChanceTable Table;
 
-    SimpleBitChance(int chanceIn = 0x800) {
-        chance = chanceIn;
+    SimpleBitChance() {
+        chance = 0x800;
     }
 
-    uint16_t inline get() const {
-        return chance; //*16; // return 16-bit number
+    uint16_t inline get_12bit() const {
+        return chance;
     }
-    void set(uint16_t chance) {
+    void set_12bit(uint16_t chance) {
         this->chance = chance;
     }
     void inline put(bool bit, const Table &table) {
@@ -128,7 +91,7 @@ public:
     MultiscaleBitChanceTable(int cut = 8) {
         for (int i= 0; i<N; i++) {
             subTable[i].init(cut, MULTISCALE_ALPHAS[i]);
-          }
+        }
     }
 };
 
@@ -147,11 +110,11 @@ protected:
 public:
     typedef MultiscaleBitChanceTable<N,BitChance> Table;
 
-    MultiscaleBitChance(int chanceIn = 0x800) {
-        set(chanceIn);
+    MultiscaleBitChance() {
+        set_12bit(0x800);
     }
 
-    void set(uint16_t chanceIn) {
+    void set_12bit(uint16_t chanceIn) {
         for (int i = 0; i<N; i++) {
             chances[i].set(chanceIn);
             quality[i] = 0;
@@ -166,7 +129,7 @@ public:
 #endif
     }
 
-    uint16_t get() const {
+    uint16_t get_12bit() const {
         return chances[best].get();
     }
 

--- a/maniac/chance.hpp
+++ b/maniac/chance.hpp
@@ -4,11 +4,6 @@
 #include <math.h>
 #include <stdint.h>
 
-#ifdef STATS
-#include <stdlib.h>
-#include <stdio.h>
-#endif
-
 struct Log4kTable {
     uint16_t data[4097];
     int scale;
@@ -63,14 +58,6 @@ public:
     int scale() const {
         return log4k.scale;
     }
-
-#ifdef STATS
-    void dist(std::vector<double> &dist) const {}
-
-    void info_bitchance() const {
-        printf("\n");
-    }
-#endif
 };
 
 
@@ -101,11 +88,6 @@ protected:
     BitChance chances[N];
     uint32_t quality[N];
     uint8_t best;
-#ifdef STATS
-    uint64_t virtSize[N];
-    uint64_t realSize;
-    uint64_t symbols;
-#endif
 
 public:
     typedef MultiscaleBitChanceTable<N,BitChance> Table;
@@ -118,15 +100,8 @@ public:
         for (int i = 0; i<N; i++) {
             chances[i].set(chanceIn);
             quality[i] = 0;
-#ifdef STATS
-            virtSize[i] = 0;
-#endif
         }
         best = 0;
-#ifdef STATS
-        symbols = 0;
-        realSize = 0;
-#endif
     }
 
     uint16_t get_12bit() const {
@@ -134,10 +109,6 @@ public:
     }
 
     void put(bool bit, const Table &table) {
-#ifdef STATS
-        int oldBest = best;
-        symbols++;
-#endif
 /*        if (bit == 0)  {
           for (int i=0; i<N; i++) {
             uint64_t sbits = 0;
@@ -169,10 +140,6 @@ public:
 //            quality[i] = (oqual*127 + sbits*2049 + 64)>>7;
 //            if (quality[i] < quality[best]) best=i;
             chances[i].put(bit, table.subTable[i]);
-#ifdef STATS
-            virtSize[i] += sbits;
-            if (i == oldBest) realSize += sbits;
-#endif
         }
 
         for (int i=0; i<N; i++) if (quality[i] < quality[best]) best=i;
@@ -186,24 +153,6 @@ public:
         return chances[0].scale();
     }
 
-#ifdef STATS
-    void dist(std::vector<double> &ret) const {
-        if (ret.size() != N+1)
-            ret = std::vector<double>(N+1, 0.0);
-
-        ret[0] += (double)realSize/scale();
-        for (int i=0; i<N; i++)
-            ret[i+1] += (double)virtSize[i]/scale();
-    }
-
-    void info_bitchance() const {
-        printf("%llu bits: ", (unsigned long long)symbols);
-        printf("%.5f [", (double)symbols*scale()/realSize);
-        for (int i=0; i<N; i++)
-            printf("%.4f ", (double)symbols*scale()/virtSize[i]);
-        printf("]\n");
-    }
-#endif
 };
 
 #endif

--- a/maniac/compound.hpp
+++ b/maniac/compound.hpp
@@ -153,7 +153,7 @@ public:
 
     bool inline read(const SymbolChanceBitType type, const int i = 0) {
         BitChance& ch = chances.realChances.bit(type, i);
-        bool bit = rac.read(ch.get());
+        bool bit = rac.read_12bit_chance(ch.get_12bit());
         updateChances(type, i, bit);
         return bit;
     }
@@ -161,7 +161,7 @@ public:
 #ifdef HAS_ENCODER
     void inline write(const bool bit, const SymbolChanceBitType type, const int i = 0) {
         BitChance& ch = chances.realChances.bit(type, i);
-        rac.write(ch.get(), bit);
+        rac.write_12bit_chance(ch.get_12bit(), bit);
         updateChances(type, i, bit);
     }
 #endif
@@ -222,7 +222,7 @@ public:
 
     bool read(SymbolChanceBitType type, int i = 0) {
         BitChance& ch = bestChance(type, i);
-        bool bit = rac.read(ch.get());
+        bool bit = rac.read_12bit_chance(ch.get_12bit());
         updateChances(type, i, bit);
 //    e_printf("bit %s%i = %s\n", SymbolChanceBitName[type], i, bit ? "true" : "false");
         return bit;
@@ -230,7 +230,7 @@ public:
 
     void write(bool bit, SymbolChanceBitType type, int i = 0) {
         BitChance& ch = bestChance(type, i);
-        rac.write(ch.get(), bit);
+        rac.write_12bit_chance(ch.get_12bit(), bit);
         updateChances(type, i, bit);
 //    e_printf("bit %s%i = %s\n", SymbolChanceBitName[type], i, bit ? "true" : "false");
     }

--- a/maniac/compound.hpp
+++ b/maniac/compound.hpp
@@ -29,25 +29,6 @@ public:
 
 class Tree : public std::vector<PropertyDecisionNode>
 {
-#ifdef STATS
-protected:
-    void print_subtree(FILE* file, int pos, int indent) const {
-        const PropertyDecisionNode &n = (*this)[pos];
-        for (int i=0; i<2*indent; i++) fputc(' ', file);
-        if (n.property == -1)
-            fprintf(file, "* leaf id=%i\n", n.leafID);
-        else {
-            fprintf(file, "* split on prop %i at val %i after %lli steps\n", n.property, n.splitval, (long long int)n.count);
-            print_subtree(file, n.childID, indent+1);
-            print_subtree(file, n.childID+1, indent+1);
-        }
-    }
-public:
-    void print(FILE *file) const {
-        print_subtree(file, 0, 0);
-    }
-
-#endif
 
 public:
     Tree() : std::vector<PropertyDecisionNode>(1, PropertyDecisionNode()) {}
@@ -57,46 +38,13 @@ public:
 template <typename BitChance, int bits> class FinalCompoundSymbolChances
 {
 public:
-#ifdef STATS
-    int64_t s_count;
-    double sum;
-    double qsum;
-#endif
     SymbolChance<BitChance, bits> realChances;
 
     FinalCompoundSymbolChances() {
-#ifdef STATS
-        s_count = 0;
-        sum = 0.0;
-        qsum = 0.0;
-#endif
     }
 
     const SymbolChance<BitChance, bits> &chances() const { return realChances; }
 
-#ifdef STATS
-    void info(int n) const {
-        std::vector<double> chs;
-        realChances.dist(chs);
-        indent(n); printf("Chances:\n");
-        indent(n+1); printf("Totals ints: %llu\n" , (unsigned long long)s_count);
-        indent(n+1); printf("Total bits/int: %.4f [", chs[0]/s_count);
-        double bestchs = 1.0/0.0;
-        int bestidx = -1;
-        for (unsigned int i=1; i<chs.size(); i++) {
-            printf("%.4f ", chs[i]/s_count);
-            if (chs[i] < bestchs) {
-               bestchs = chs[i];
-               bestidx = i-1;
-            }
-        }
-        printf("]\n");
-//        indent(n+1); printf("Average: %.3f+=%.3f (normal optimal bits/int: %.3f)\n", mu, sigma, nbps);
-        indent(n+1); printf("Loss for const scale: %.1f bits (%.1f cnp)\n", bestchs - chs[0], log(bestchs/chs[0])*100.0);
-        indent(n+1); printf("Best scale: %i\n", bestidx);
-        realChances.info_symbol(n+1);
-    }
-#endif
 };
 
 #ifdef HAS_ENCODER
@@ -251,19 +199,12 @@ public:
     int read_int(FinalCompoundSymbolChances<BitChance, bits> &chancesIn, int min, int max) {
         FinalCompoundSymbolBitCoder<BitChance, RAC, bits> bitCoder(table, rac, chancesIn);
         int val = reader<bits>(bitCoder, min, max);
-//        printf("%i in %i..%i\n",val, min, max);
         return val;
     }
 
 #ifdef HAS_ENCODER
     void write_int(FinalCompoundSymbolChances<BitChance, bits>& chancesIn, int min, int max, int val) {
-#ifdef STATS
-        chancesIn.sum += (double)val;
-        chancesIn.qsum += (double)val*val;
-        chancesIn.s_count++;
-#endif
         FinalCompoundSymbolBitCoder<BitChance, RAC, bits> bitCoder(table, rac, chancesIn);
-//        printf("%i in %i..%i\n",val, min, max);
         writer<bits>(bitCoder, min, max, val);
     }
 #endif
@@ -276,11 +217,6 @@ public:
 
 #ifdef HAS_ENCODER
     void write_int(FinalCompoundSymbolChances<BitChance, bits>& chancesIn, int nbits, int val) {
-#ifdef STATS
-        chancesIn.sum += (double)val;
-        chancesIn.qsum += (double)val*val;
-        chancesIn.s_count++;
-#endif
         FinalCompoundSymbolBitCoder<BitChance, RAC, bits> bitCoder(table, rac, chancesIn);
         writer(bitCoder, nbits, val);
     }
@@ -408,15 +344,6 @@ public:
     }
 #endif
 
-#ifdef STATS
-    void info(int n) const {
-        indent(n); printf("Tree:\n");
-        for (unsigned int i=0; i<leaf_node.size(); i++) {
-            indent(n); printf("Leaf %u\n", i);
-            leaf_node[i].info(n+1);
-        }
-    }
-#endif
     void simplify(int divisor=CONTEXT_TREE_COUNT_DIV, int min_size=CONTEXT_TREE_MIN_SUBTREE_SIZE) {}
 };
 
@@ -436,9 +363,6 @@ private:
     Tree &inner_node;
     std::vector<bool> selection;
     int split_threshold;
-#ifdef STATS
-    uint64_t symbols;
-#endif
 
     CompoundSymbolChances<BitChance,bits> inline &find_leaf(const Properties &properties) {
         uint32_t pos = 0;
@@ -519,15 +443,9 @@ public:
         inner_node(treeIn),
         selection(nb_properties,false),
         split_threshold(st) {
-#ifdef STATS
-            symbols = 0;
-#endif
     }
 
     int read_int(Properties &properties, int min, int max) {
-#ifdef STATS
-        symbols++;
-#endif
         CompoundSymbolChances<BitChance,bits> &chances = find_leaf(properties);
         set_selection_and_update_property_sums(properties,chances);
         CompoundSymbolChances<BitChance,bits> &chances2 = find_leaf(properties);
@@ -535,9 +453,6 @@ public:
     }
 
     void write_int(Properties &properties, int min, int max, int val) {
-#ifdef STATS
-        symbols++;
-#endif
         CompoundSymbolChances<BitChance,bits> &chances = find_leaf(properties);
         set_selection_and_update_property_sums(properties,chances);
         CompoundSymbolChances<BitChance,bits> &chances2 = find_leaf(properties);
@@ -545,9 +460,6 @@ public:
     }
 
     int read_int(Properties &properties, int nbits) {
-#ifdef STATS
-        symbols++;
-#endif
         CompoundSymbolChances<BitChance,bits> &chances = find_leaf(properties);
         set_selection_and_update_property_sums(properties,chances);
         CompoundSymbolChances<BitChance,bits> &chances2 = find_leaf(properties);
@@ -555,20 +467,11 @@ public:
     }
 
     void write_int(Properties &properties, int nbits, int val) {
-#ifdef STATS
-        symbols++;
-#endif
         CompoundSymbolChances<BitChance,bits> &chances = find_leaf(properties);
         set_selection_and_update_property_sums(properties,chances);
         CompoundSymbolChances<BitChance,bits> &chances2 = find_leaf(properties);
         coder.write_int(chances2, selection, nbits, val);
     }
-
-#ifdef STATS
-    void info(int n) const {
-    }
-#endif
-
 
     // destructive simplification procedure, prunes subtrees with too low counts
     long long int simplify_subtree(int pos, int divisor, int min_size) {

--- a/maniac/symbol.cpp
+++ b/maniac/symbol.cpp
@@ -1,0 +1,24 @@
+#include <sstream>
+
+#include "symbol.hpp"
+
+#ifdef STATS
+std::string SymbolChanceStats::format() const {
+    std::stringstream ss;
+    ss << "0:" << stats_zero.format() << ' ';
+    ss << "-:" << stats_sign.format() << ' ';
+    for (int i = 0; i < 31; i++) {
+        ss << "e" << i << ":" << stats_exp[i].format() << ' ';
+    }
+    for (int i = 0; i < 32; i++) {
+        ss << "m" << i << ":" << stats_mant[i].format() << ' ';
+    }
+    return ss.str();
+}
+
+SymbolChanceStats::~SymbolChanceStats() {
+    fprintf(stderr, "STATS: %s\n", format().c_str());
+}
+
+SymbolChanceStats global_symbol_stats;
+#endif

--- a/maniac/symbol.hpp
+++ b/maniac/symbol.hpp
@@ -28,10 +28,10 @@ public:
         // split in [0..med] [med+1..max]
         int med = max/2;
         if (val > med) {
-            rac.write(med+1, max+1, true);
+            rac.write_fractional(med+1, max+1, true);
             write_int(med+1, max, val);
         } else {
-            rac.write(med+1, max+1, false);
+            rac.write_fractional(med+1, max+1, false);
             write_int(0, med, val);
         }
         return;
@@ -46,7 +46,7 @@ public:
 
         // split in [0..med] [med+1..max]
         int med = max/2;
-        bool bit = rac.read(med+1, max+1);
+        bool bit = rac.read_fractional(med+1, max+1);
         if (bit) {
             return read_int(min+med+1, min+max);
         } else {
@@ -115,14 +115,14 @@ public:
         }
     }
     SymbolChance() { // : bit_exp(bitsin-1), bit_mant(bitsin) {
-        bitZero().set(ZERO_CHANCE);
-        bitSign().set(SIGN_CHANCE);
+        bitZero().set_12bit(ZERO_CHANCE);
+        bitSign().set_12bit(SIGN_CHANCE);
 //        printf("bits: %i\n",bits);
         for (int i=0; i<bits-1; i++) {
-            bitExp(i).set(EXP_CHANCES[i]);
+            bitExp(i).set_12bit(EXP_CHANCES[i]);
         }
         for (int i=0; i<bits; i++) {
-            bitMant(i).set(MANT_CHANCES[i]);
+            bitMant(i).set_12bit(MANT_CHANCES[i]);
         }
     }
 
@@ -340,15 +340,15 @@ public:
     SimpleSymbolBitCoder(const Table &tableIn, SymbolChance<BitChance,bits> &ctxIn, RAC &racIn) : table(tableIn), ctx(ctxIn), rac(racIn) {}
 
     void write(bool bit, SymbolChanceBitType typ, int i = 0) {
-        BitChance& bch = ctx.bit(typ,i);
-        rac.write(bch.get(), bit);
+        BitChance& bch = ctx.bit(typ, i);
+        rac.write_12bit_chance(bch.get_12bit(), bit);
         bch.put(bit, table);
 //    e_printf("bit %s%i = %s\n", SymbolChanceBitName[typ], i, bit ? "true" : "false");
     }
 
     bool read(SymbolChanceBitType typ, int i = 0) {
-        BitChance& bch = ctx.bit(typ,i);
-        bool bit = rac.read(bch.get());
+        BitChance& bch = ctx.bit(typ, i);
+        bool bit = rac.read_12bit_chance(bch.get_12bit());
         bch.put(bit, table);
 //    e_printf("bit %s%i = %s\n", SymbolChanceBitName[typ], i, bit ? "true" : "false");
         return bit;


### PR DESCRIPTION
This removes the older stats code (unsure if it was being used, or even still compiled?), and replaces it with new statistics per bit in the exponential-notation symbols.

It would be useful to determine good initial chances for those (see EXP_CHANCES etc in maniac/symbol.hpp), as I believe their values are guessed based on just a few or even just one image.

To run, compile flif.stats, and decode as many flif images as possible (using it for encoding will also report numbers for the maniac iterations, which don't actually output data, so it's faster and more accurate to run for decoding).