### PR TITLE
makefile: put binary names at the end of build command, for easier identification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,37 +11,37 @@ FILES_CPP := maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cp
 all: flif libflif.so viewflif
 
 flif: $(FILES_H) $(FILES_CPP) flif.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall $(FILES_CPP) flif.cpp -o flif $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif
 
 flif.stats: $(FILES_H) $(FILES_CPP) flif.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DSTATS -DNDEBUG -O3 -g0 -Wall $(FILES_CPP) flif.cpp -o flif.stats $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DSTATS -DNDEBUG -O3 -g0 -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif.stats
 
 flif.prof: $(FILES_H) $(FILES_CPP) flif.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -pg -Wall $(FILES_CPP) flif.cpp -o flif.prof $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -pg -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif.prof
 
 flif.dbg: $(FILES_H) $(FILES_CPP) flif.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -O0 -ggdb3 -Wall $(FILES_CPP) flif.cpp -o flif.dbg $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -O0 -ggdb3 -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif.dbg
 
 flif.asan: $(FILES_H) $(FILES_CPP) flif.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -O3 -fsanitize=address,undefined -fno-omit-frame-pointer -g3 -Wall $(FILES_CPP) flif.cpp -o flif.asan $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -O3 -fsanitize=address,undefined -fno-omit-frame-pointer -g3 -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif.asan
 
 libflif.so: $(FILES_H) $(FILES_CPP) flif.h flif-interface-private.h flif-interface.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp -o libflif.so $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp $(LDFLAGS) -o libflif.so
 
 libflif.prof.so: $(FILES_H) $(FILES_CPP) flif.h flif-interface-private.h flif-interface.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -pg -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp -o libflif.prof.so $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -pg -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp $(LDFLAGS) -o libflif.prof.so
 
 libflif.dbg.so: $(FILES_H) $(FILES_CPP) flif.h flif-interface-private.h flif-interface.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -O1 -ggdb3 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp -o libflif.dbg.so $(LDFLAGS)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -O1 -ggdb3 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp $(LDFLAGS) -o libflif.dbg.so
 
 viewflif: libflif.so flif.h viewflif.c
-	$(CC) -std=gnu11 -O2 -ggdb3 $(shell sdl2-config --cflags) -Wall -I. viewflif.c -o viewflif -L. -lflif $(shell sdl2-config --libs)
+	$(CC) -std=gnu11 -O2 -ggdb3 $(shell sdl2-config --cflags) -Wall -I. viewflif.c -L. -lflif $(shell sdl2-config --libs) -o viewflif
 
 viewflif.prof: libflif.prof.so flif.h viewflif.c
-	$(CC) -std=gnu11 -O2 -pg -ggdb3 $(shell sdl2-config --cflags) -Wall -I. viewflif.c -o viewflif.prof -L. -lflif.prof $(shell sdl2-config --libs)
+	$(CC) -std=gnu11 -O2 -pg -ggdb3 $(shell sdl2-config --cflags) -Wall -I. viewflif.c -L. -lflif.prof $(shell sdl2-config --libs) -o viewflif.prof
 
 test-interface: libflif.dbg.so flif.h tools/test.c
-	$(CC) -O0 -ggdb3 -Wall -I. tools/test.c -o test-interface -L. -lflif.dbg
+	$(CC) -O0 -ggdb3 -Wall -I. tools/test.c -L. -lflif.dbg  -o test-interface
 
 install: all
 	install -s -m 755 flif viewflif $(PREFIX)/bin


### PR DESCRIPTION
old:

g++ -std=gnu++11 -I/usr/include/libpng16  -DNDEBUG -O3 -g0 -Wall maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/image-rggb.cpp image/color_range.cpp transform/factory.cpp common.cpp flif-enc.cpp flif-dec.cpp io.cpp flif.cpp -o flif -L/usr/lib64 -lz -lpng16 
g++ -std=gnu++11 -I/usr/include/libpng16  -DNDEBUG -O3 -g0 -Wall -shared -fPIC maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/image-rggb.cpp image/color_range.cpp transform/factory.cpp common.cpp flif-enc.cpp flif-dec.cpp io.cpp flif-interface.cpp -o libflif.so -L/usr/lib64 -lz -lpng16 

new:

g++ -std=gnu++11 -I/usr/include/libpng16  -DNDEBUG -O3 -g0 -Wall maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/image-rggb.cpp image/color_range.cpp transform/factory.cpp common.cpp flif-enc.cpp flif-dec.cpp io.cpp flif.cpp -L/usr/lib64 -lz -lpng16  -o flif
g++ -std=gnu++11 -I/usr/include/libpng16  -DNDEBUG -O3 -g0 -Wall -shared -fPIC maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/image-rggb.cpp image/color_range.cpp transform/factory.cpp common.cpp flif-enc.cpp flif-dec.cpp io.cpp flif-interface.cpp -L/usr/lib64 -lz -lpng16  -o libflif.so
