### PR TITLE
IO abstraction 

### DIFF
--- a/fileio.hpp
+++ b/fileio.hpp
@@ -242,28 +242,3 @@ public:
     }
 };
 
-template<class IO>
-bool fget_int_8bit (IO& io, int* result)
-{
-    int c = io.getc();
-    if (c == io.EOS) {
-        e_printf ("Unexpected EOF");
-        return false;
-    }
-
-    *result = c;
-    return true;
-}
-
-template<class IO>
-bool fget_int_16bit_bigendian (IO& io, int* result)
-{
-    int c1;
-    int c2;
-    if (!(fget_int_8bit (io, &c1) &&
-          fget_int_8bit (io, &c2)))
-        return false;
-
-    *result = (c1 << 8) + c2;
-    return true;
-}

--- a/flif-dec.cpp
+++ b/flif-dec.cpp
@@ -383,18 +383,18 @@ bool flif_decode(IO& io, Images &images, int quality, int scale, uint32_t (*call
     }
     if (strcmp(buff,"FLIF")) { e_printf("Not a FLIF file: %s (header: \"%s\")\n",io.getName(),buff); return false; }
     int c;
-    if (!fget_int_8bit (io, &c))
+    if (!ioget_int_8bit (io, &c))
         return false;
     if (c < ' ' || c > ' '+32+15+32) { e_printf("Invalid or unknown FLIF format byte\n"); return false;}
     c -= ' ';
     int numFrames=1;
     if (c > 47) {
         c -= 32;
-        if (!fget_int_8bit (io, &numFrames))
+        if (!ioget_int_8bit (io, &numFrames))
             return false;
         if (numFrames < 2 || numFrames >= 256) return false;
         if (numFrames == 0xff) {
-          if (!fget_int_16bit_bigendian (io, &numFrames))
+          if (!ioget_int_16bit_bigendian (io, &numFrames))
             return false;
         }
     }
@@ -404,15 +404,15 @@ bool flif_decode(IO& io, Images &images, int quality, int scale, uint32_t (*call
     if (quality < 100 && encoding==1) { v_printf(1,"Cannot decode non-interlaced FLIF file at lower quality! Ignoring quality...\n");}
     int numPlanes=c%16;
     if (numPlanes < 1 || numPlanes > 4) {e_printf("Invalid FLIF header (unsupported color channels)\n"); return false;}
-    if (!fget_int_8bit (io, &c))
+    if (!ioget_int_8bit (io, &c))
         return false;
     if (c < '0' || c > '2')  {e_printf("Invalid FLIF header (unsupported color depth)\n"); return false;}
 
     int width;
     int height;
-    if (!fget_int_16bit_bigendian (io, &width))
+    if (!ioget_int_16bit_bigendian (io, &width))
         return false;
-    if (!fget_int_16bit_bigendian (io, &height))
+    if (!ioget_int_16bit_bigendian (io, &height))
         return false;
     if (width < 1 || height < 1) {e_printf("Invalid FLIF header\n"); return false;}
 

--- a/io.hpp
+++ b/io.hpp
@@ -7,7 +7,7 @@ void increase_verbosity();
 int get_verbosity();
 
 template<class IO>
-bool fget_int_8bit (IO& io, int* result)
+bool ioget_int_8bit (IO& io, int* result)
 {
     int c = io.getc();
     if (c == io.EOS) {
@@ -20,12 +20,12 @@ bool fget_int_8bit (IO& io, int* result)
 }
 
 template<class IO>
-bool fget_int_16bit_bigendian (IO& io, int* result)
+bool ioget_int_16bit_bigendian (IO& io, int* result)
 {
     int c1;
     int c2;
-    if (!(fget_int_8bit (io, &c1) &&
-          fget_int_8bit (io, &c2)))
+    if (!(ioget_int_8bit (io, &c1) &&
+          ioget_int_8bit (io, &c2)))
         return false;
 
     *result = (c1 << 8) + c2;

--- a/io.hpp
+++ b/io.hpp
@@ -5,3 +5,29 @@ void v_printf(const int v, const char *format, ...);
 
 void increase_verbosity();
 int get_verbosity();
+
+template<class IO>
+bool fget_int_8bit (IO& io, int* result)
+{
+    int c = io.getc();
+    if (c == io.EOS) {
+        e_printf ("Unexpected EOS");
+        return false;
+    }
+
+    *result = c;
+    return true;
+}
+
+template<class IO>
+bool fget_int_16bit_bigendian (IO& io, int* result)
+{
+    int c1;
+    int c2;
+    if (!(fget_int_8bit (io, &c1) &&
+          fget_int_8bit (io, &c2)))
+        return false;
+
+    *result = (c1 << 8) + c2;
+    return true;
+}


### PR DESCRIPTION
IO abstraction police at work:

* move fget* to io.hpp (because fileio.hpp is not used by the emscript port)
* rename fget* to ioget*