### PR TITLE
make some functions static/const as suggested by cppcheck, rework makefile to work better with clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,19 @@
 
-*.flif
+# binarys
+src/flif
+src/flif.asan
+src/flif.dbg
+src/flif.prof
+src/flif.stats
+src/libflif.dbg.so
+src/libflif.so
+src/test-interface
+src/viewflif
 
 *.png
 *.xcworkspace/*
 *.xcworkspace
 *.xcodeproj
-flif
 
 flif.osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 
 compiler:
   - gcc
+  - clang
 
 sudo: true
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ remove:
 	rm -f $(PREFIX)/share/man/man1/flif.1
 
 clean:
-	rm -f flif libflif*.so viewflif
+	rm -f flif libflif*.so viewflif flif.asan flif.dbg flif.prof flif.stats
 
 test: flif test-interface
 	mkdir -p ../tmp-test

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,17 @@ FILES_CPP := maniac/chance.cpp maniac/symbol.cpp image/crc32k.cpp image/image.cp
 all: flif libflif.so viewflif
 
 # options to consider: -ftree-vectorize -fvect-cost-model=unlimited -funroll-all-loops
-OPTIMIZATIONS := -DNDEBUG -O3 -flto -fwhole-program -ftree-vectorize
+OPTIMIZATIONS := -DNDEBUG -O3 -ftree-vectorize
+# there are often problems with clang and lto also it doesn't seem to know -fwhole-program
+ifeq ($(CXX), g++)
+	OPTIMIZATIONS := $(OPTIMIZATIONS) -flto -fwhole-program
+endif
+
+LIB_OPTIMIZATIONS := -DNDEBUG -O3
+ifeq ($(CXX), g++)
+	LIB_OPTIMIZATIONS := $(LIB_OPTIMIZATIONS) -flto
+endif
+
 flif: $(FILES_H) $(FILES_CPP) flif.cpp
 	$(CXX) -std=gnu++11 $(CXXFLAGS) $(OPTIMIZATIONS) -g0 -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif
 
@@ -28,7 +38,7 @@ flif.asan: $(FILES_H) $(FILES_CPP) flif.cpp
 	$(CXX) -std=gnu++11 $(CXXFLAGS) $(OPTIMIZATIONS) -fsanitize=address,undefined -fno-omit-frame-pointer -g3 -Wall $(FILES_CPP) flif.cpp $(LDFLAGS) -o flif.asan
 
 libflif.so: $(FILES_H) $(FILES_CPP) flif.h flif-interface-private.h flif-interface.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -flto -g0 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp $(LDFLAGS) -o libflif.so
+	$(CXX) -std=gnu++11 $(CXXFLAGS) $(LIB_OPTIMIZATIONS) -g0 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp $(LDFLAGS) -o libflif.so
 
 libflif.dbg.so: $(FILES_H) $(FILES_CPP) flif.h flif-interface-private.h flif-interface.cpp
 	$(CXX) -std=gnu++11 $(CXXFLAGS) -O1 -ggdb3 -Wall -shared -fPIC $(FILES_CPP) flif-interface.cpp $(LDFLAGS) -o libflif.dbg.so

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -110,7 +110,7 @@ public:
             break;
         }
     }
-    const char* getName() {
+    static const char* getName() {
         return "BlobReader";
     }
 };
@@ -178,7 +178,7 @@ public:
         return ptr;
     }
 
-    void flush() {
+    static void flush() {
         // nothing to do
     }
     bool isEOF() const {
@@ -237,7 +237,7 @@ public:
             break;
         }
     }
-    const char* getName() {
+    static const char* getName() {
         return "BlobIO";
     }
 };

--- a/src/maniac/compound.hpp
+++ b/src/maniac/compound.hpp
@@ -344,7 +344,7 @@ public:
     }
 #endif
 
-    void simplify(int divisor=CONTEXT_TREE_COUNT_DIV, int min_size=CONTEXT_TREE_MIN_SUBTREE_SIZE) {}
+    static void simplify(int divisor=CONTEXT_TREE_COUNT_DIV, int min_size=CONTEXT_TREE_MIN_SUBTREE_SIZE) {}
 };
 
 

--- a/src/maniac/rac.hpp
+++ b/src/maniac/rac.hpp
@@ -176,9 +176,9 @@ public:
 class RacDummy
 {
 public:
-    void inline write_12bit_chance(uint16_t b12, bool) { }
-    void inline write_bit(bool) { }
-    void inline flush() { }
+    static void inline write_12bit_chance(uint16_t b12, bool) { }
+    static void inline write_bit(bool) { }
+    static void inline flush() { }
 };
 
 

--- a/src/transform/colorbuckets.hpp
+++ b/src/transform/colorbuckets.hpp
@@ -360,7 +360,7 @@ protected:
         }
     }
 
-    ColorBucket load_bucket(SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> &coder, const ColorRanges *srcRanges, const int plane, const prevPlanes &pixelL, const prevPlanes &pixelU) {
+    ColorBucket const load_bucket(SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> &coder, const ColorRanges *srcRanges, const int plane, const prevPlanes &pixelL, const prevPlanes &pixelU) {
         ColorBucket b;
         if (plane<3)
         for (int p=0; p<plane; p++) {


### PR DESCRIPTION
Some functions can be made static/const according to cppcheck, I modified all functions that did not cause the build to break and ran 'make test', but I'd still like someone to read through it and see if everything is correct.

About the makefile, a lot of distros (ubuntu/travis-ci as well) lack LTO support on clang, thus I disabled -flto if building via 'make CXX=clang++'2

I also update the gitignore and "make clean" to know latest binary paths (binarys are dumped into ./src since a few days).