### PR TITLE
eliminate `grey` in prediction

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -45,9 +45,8 @@ ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRang
       }
       if (image.numPlanes()>3) properties[index++] = image(3,r,c);
     }
-    assert((c > 0) || (r > 0));   // can't predict the pixel at 0,0
-    ColorVal left = (c>0 ? image(p,r,c-1) : image(p, r-1, c));
-    ColorVal top = (r>0 ? image(p,r-1,c) : image(p, r, c-1));
+    ColorVal left = (c>0 ? image(p,r,c-1) : (r > 0 ? image(p, r-1, c) : ((min + max) / 2)));
+    ColorVal top = (r>0 ? image(p,r-1,c) : left);
     ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : (r > 0 ? top : left));
     ColorVal gradientTL = left + top - topleft;
     guess = median3(gradientTL, left, top);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,7 +1,5 @@
 #include "common.hpp"
 
-std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
-
 const std::vector<std::string> transforms = {"PLC","YIQ","BND","PLA","PLT","ACB","DUP","FRS","FRA","???"};
 uint8_t transform_l = 0;
 
@@ -47,9 +45,10 @@ ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRang
       }
       if (image.numPlanes()>3) properties[index++] = image(3,r,c);
     }
-    ColorVal left = (c>0 ? image(p,r,c-1) : grey[p]);;
-    ColorVal top = (r>0 ? image(p,r-1,c) : grey[p]);
-    ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : grey[p]);
+    assert((c > 0) || (r > 0));   // can't predict the pixel at 0,0
+    ColorVal left = (c>0 ? image(p,r,c-1) : image(p, r-1, c));
+    ColorVal top = (r>0 ? image(p,r-1,c) : image(p, r, c-1));
+    ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : (r > 0 ? top : left));
     ColorVal gradientTL = left + top - topleft;
     guess = median3(gradientTL, left, top);
     ranges->snap(p,properties,min,max,guess);
@@ -118,16 +117,19 @@ ColorVal predict_and_calcProps(Properties &properties, const ColorRanges *ranges
     }
     ColorVal left;
     ColorVal top;
-    ColorVal topleft = (r>0 && c>0 ? image(p,z,r-1,c-1) : grey[p]);
-    ColorVal topright = (r>0 && c+1 < image.cols(z) ? image(p,z,r-1,c+1) : grey[p]);
-    ColorVal bottomleft = (r+1 < image.rows(z) && c>0 ? image(p,z,r+1,c-1) : grey[p]);
+    ColorVal topleft;
+    ColorVal topright;
     if (z%2 == 0) { // filling horizontal lines
-      left = (c>0 ? image(p,z,r,c-1) : grey[p]);
       top = image(p,z,r-1,c);
-      ColorVal gradientTL = left + top - topleft;
-      ColorVal bottom = (r+1 < image.rows(z) ? image(p,z,r+1,c) : top); //grey[p]);
-      ColorVal gradientBL = left + bottom - bottomleft;
-      ColorVal avg = (top + bottom)>>1;
+      left = (c>0 ? image(p,z,r,c-1) : top);
+      topleft = (c>0 ? image(p,z,r-1,c-1) : top);
+      topright = (c+1 < image.cols(z) ? image(p,z,r-1,c+1) : top);
+      const ColorVal gradientTL = left + top - topleft;
+      const bool bottomPresent = r+1 < image.rows(z);
+      const ColorVal bottom = (bottomPresent ? image(p,z,r+1,c) : left);
+      const ColorVal bottomleft = (bottomPresent && c>0 ? image(p,z,r+1,c-1) : bottom);
+      const ColorVal gradientBL = left + bottom - bottomleft;
+      const ColorVal avg = (top + bottom)>>1;
       guess = median3(gradientTL, gradientBL, avg);
       ranges->snap(p,properties,min,max,guess);
       if (guess == avg) which = 0;
@@ -136,10 +138,13 @@ ColorVal predict_and_calcProps(Properties &properties, const ColorRanges *ranges
       properties[index++] = top-bottom;
     } else { // filling vertical lines
       left = image(p,z,r,c-1);
-      top = (r>0 ? image(p,z,r-1,c) : grey[p]);
-      ColorVal gradientTL = left + top - topleft;
-      ColorVal right = (c+1 < image.cols(z) ? image(p,z,r,c+1) : left); //grey[p]);
-      ColorVal gradientTR = right + top - topright;
+      top = (r>0 ? image(p,z,r-1,c) : left);
+      topleft = (r>0 ? image(p,z,r-1,c-1) : left);
+      const bool rightPresent = c+1 < image.cols(z);
+      const ColorVal right = (rightPresent ? image(p,z,r,c+1) : top);
+      topright = (r>0 && rightPresent ? image(p,z,r-1,c+1) : right);
+      const ColorVal gradientTL = left + top - topleft;
+      const ColorVal gradientTR = right + top - topright;
       ColorVal avg = (left + right)>>1;
       guess = median3(gradientTL, gradientTR, avg);
       ranges->snap(p,properties,min,max,guess);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -35,7 +35,7 @@ void initPropRanges_scanlines(Ranges &propRanges, const ColorRanges &ranges, int
     propRanges.push_back(std::make_pair(mind,maxd));
 }
 
-ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRanges *ranges, const Image &image, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max) {
+ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRanges *ranges, const Image &image, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max, const ColorVal fallback) {
     ColorVal guess;
     int which = 0;
     int index=0;
@@ -45,7 +45,7 @@ ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRang
       }
       if (image.numPlanes()>3) properties[index++] = image(3,r,c);
     }
-    ColorVal left = (c>0 ? image(p,r,c-1) : (r > 0 ? image(p, r-1, c) : ((min + max) / 2)));
+    ColorVal left = (c>0 ? image(p,r,c-1) : (r > 0 ? image(p, r-1, c) : fallback));
     ColorVal top = (r>0 ? image(p,r-1,c) : left);
     ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : (r > 0 ? top : left));
     ColorVal gradientTL = left + top - topleft;
@@ -215,4 +215,3 @@ std::pair<int, int> plane_zoomlevel(const Image &image, const int beginZL, const
 
     return std::pair<int, int>(p,zl);
 }
-

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -75,11 +75,9 @@ template<typename I> I inline median3(I a, I b, I c) {
 }
 
 // Prediction used for interpolation / alpha=0 pixels. Does not have to be the same as the guess used for encoding/decoding.
-inline ColorVal predict(const Image &image, int p, uint32_t r, uint32_t c) {
-    assert((c > 0) || (r > 0));   // can't predict the pixel at 0,0
-
-    ColorVal left = (c>0 ? image(p,r,c-1) : image(p, r-1, c));
-    ColorVal top = (r>0 ? image(p,r-1,c) : image(p, r, c-1));
+inline ColorVal predictScanlines(const Image &image, int p, uint32_t r, uint32_t c, ColorVal grey) {
+    ColorVal left = (c>0 ? image(p,r,c-1) : (r > 0 ? image(p, r-1, c) : grey));
+    ColorVal top = (r>0 ? image(p,r-1,c) : left);
     ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : top);
     ColorVal gradientTL = left + top - topleft;
     return median3(gradientTL, left, top);

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -105,3 +105,9 @@ ColorVal predict_and_calcProps(Properties &properties, const ColorRanges *ranges
 int plane_zoomlevels(const Image &image, const int beginZL, const int endZL);
 
 std::pair<int, int> plane_zoomlevel(const Image &image, const int beginZL, const int endZL, int i);
+
+inline std::vector<ColorVal> computeGreys(const ColorRanges *ranges) {
+    std::vector<ColorVal> greys; // a pixel with values in the middle of the bounds
+    for (int p = 0; p < ranges->numPlanes(); p++) greys.push_back((ranges->min(p)+ranges->max(p))/2);
+    return greys;
+}

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -54,7 +54,7 @@ extern const int PLANE_ORDERING[];
 
 void initPropRanges_scanlines(Ranges &propRanges, const ColorRanges &ranges, int p);
 
-ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRanges *ranges, const Image &image, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max);
+ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRanges *ranges, const Image &image, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max, const ColorVal fallback);
 
 void initPropRanges(Ranges &propRanges, const ColorRanges &ranges, int p);
 

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -43,6 +43,10 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
            }
          }
     }
+
+    std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
+    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
+
     for (int k=0,i=0; k < 5; k++) {
         int p=PLANE_ORDERING[k];
         if (p>=nump) continue;
@@ -59,11 +63,11 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
               if (image.seen_before >= 0) { for(uint32_t c=0; c<image.cols(); c++) image.set(p,r,c,images[image.seen_before](p,r,c)); continue; }
               if (fr>0) {
                 for (uint32_t c = 0; c < begin; c++)
-                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predict(image,p,r,c));
+                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predictScanlines(image,p,r,c, grey[p]));
                    else if (p !=4 ) image.set(p,r,c,images[fr-1](p,r,c));
               } else if (nump>3 && p<3) { begin=0; end=image.cols(); }
               for (uint32_t c = begin; c < end; c++) {
-                if (alphazero && p<3 && image(3,r,c) == 0) {image.set(p,r,c,predict(image,p,r,c)); continue;}
+                if (alphazero && p<3 && image(3,r,c) == 0) {image.set(p,r,c,predictScanlines(image,p,r,c, grey[p])); continue;}
                 if (FRA && p<4 && image(4,r,c) > 0) {assert(fr >= image(4,r,c)); image.set(p,r,c,images[fr-image(4,r,c)](p,r,c)); continue;}
                 ColorVal guess = predict_and_calcProps_scanlines(properties,ranges,image,p,r,c,min,max);
                 if (FRA && p==4 && max > fr) max = fr;
@@ -72,7 +76,7 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
               }
               if (fr>0) {
                 for (uint32_t c = end; c < image.cols(); c++)
-                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predict(image,p,r,c));
+                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predictScanlines(image,p,r,c, grey[p]));
                    else if (p !=4 ) image.set(p,r,c,images[fr-1](p,r,c));
               }
             }

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -496,8 +496,6 @@ bool flif_decode(IO& io, Images &images, int quality, int scale, uint32_t (*call
     }
     if (tcount==0) v_printf(4,"none\n"); else v_printf(4,"\n");
     const ColorRanges* ranges = rangesList.back();
-    grey.clear();
-    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
 
     pixels_todo = (int64_t)width*height*ranges->numPlanes()/scale/scale;
     pixels_done = 0;

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -44,8 +44,7 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
          }
     }
 
-    std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
-    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
+    const std::vector<ColorVal> greys = computeGreys(ranges);
 
     for (int k=0,i=0; k < 5; k++) {
         int p=PLANE_ORDERING[k];
@@ -63,11 +62,11 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
               if (image.seen_before >= 0) { for(uint32_t c=0; c<image.cols(); c++) image.set(p,r,c,images[image.seen_before](p,r,c)); continue; }
               if (fr>0) {
                 for (uint32_t c = 0; c < begin; c++)
-                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predictScanlines(image,p,r,c, grey[p]));
+                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predictScanlines(image,p,r,c, greys[p]));
                    else if (p !=4 ) image.set(p,r,c,images[fr-1](p,r,c));
               } else if (nump>3 && p<3) { begin=0; end=image.cols(); }
               for (uint32_t c = begin; c < end; c++) {
-                if (alphazero && p<3 && image(3,r,c) == 0) {image.set(p,r,c,predictScanlines(image,p,r,c, grey[p])); continue;}
+                if (alphazero && p<3 && image(3,r,c) == 0) {image.set(p,r,c,predictScanlines(image,p,r,c, greys[p])); continue;}
                 if (FRA && p<4 && image(4,r,c) > 0) {assert(fr >= image(4,r,c)); image.set(p,r,c,images[fr-image(4,r,c)](p,r,c)); continue;}
                 ColorVal guess = predict_and_calcProps_scanlines(properties,ranges,image,p,r,c,min,max);
                 if (FRA && p==4 && max > fr) max = fr;
@@ -76,7 +75,7 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
               }
               if (fr>0) {
                 for (uint32_t c = end; c < image.cols(); c++)
-                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predictScanlines(image,p,r,c, grey[p]));
+                   if (alphazero && p<3 && image(3,r,c) == 0) image.set(p,r,c,predictScanlines(image,p,r,c, greys[p]));
                    else if (p !=4 ) image.set(p,r,c,images[fr-1](p,r,c));
               }
             }

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -52,6 +52,7 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
         i++;
         Properties properties((nump>3?NB_PROPERTIES_scanlinesA[p]:NB_PROPERTIES_scanlines[p]));
         if (ranges->min(p) < ranges->max(p)) {
+          const ColorVal minP = ranges->min(p);
           v_printf(2,"\r%i%% done [%i/%i] DEC[%ux%u]    ",(int)(100*pixels_done/pixels_todo),i,nump,images[0].cols(),images[0].rows());
           v_printf(4,"\n");
           pixels_done += images[0].cols()*images[0].rows();
@@ -68,7 +69,7 @@ template<typename IO, typename Rac, typename Coder> void flif_decode_scanlines_i
               for (uint32_t c = begin; c < end; c++) {
                 if (alphazero && p<3 && image(3,r,c) == 0) {image.set(p,r,c,predictScanlines(image,p,r,c, greys[p])); continue;}
                 if (FRA && p<4 && image(4,r,c) > 0) {assert(fr >= image(4,r,c)); image.set(p,r,c,images[fr-image(4,r,c)](p,r,c)); continue;}
-                ColorVal guess = predict_and_calcProps_scanlines(properties,ranges,image,p,r,c,min,max);
+                ColorVal guess = predict_and_calcProps_scanlines(properties,ranges,image,p,r,c,min,max, minP);
                 if (FRA && p==4 && max > fr) max = fr;
                 ColorVal curr = coders[p].read_int(properties, min - guess, max - guess) + guess;
                 image.set(p,r,c, curr);

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -193,13 +193,16 @@ void flif_encode_FLIF2_pass(IO& io, Rac &rac, const Images &images, const ColorR
     }
 }
 
-void flif_encode_FLIF2_interpol_zero_alpha(Images &images, const ColorRanges *, const int beginZL, const int endZL)
+void flif_encode_FLIF2_interpol_zero_alpha(Images &images, const ColorRanges * ranges, const int beginZL, const int endZL)
 {
+    std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
+    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
+
     for (Image& image : images) {
      if (image(3,0,0) == 0) {
-        image.set(0,0,0,grey[0]);
-        image.set(1,0,0,grey[1]);
-        image.set(2,0,0,grey[2]);
+       image.set(0,0,0,grey[0]);
+       image.set(1,0,0,grey[1]);
+       image.set(2,0,0,grey[2]);
      }
      for (int i = 0; i < plane_zoomlevels(image, beginZL, endZL); i++) {
       std::pair<int, int> pzl = plane_zoomlevel(image, beginZL, endZL, i);
@@ -431,8 +434,6 @@ bool flif_encode(IO& io, Images &images, std::vector<std::string> transDesc, fli
     if (tcount==0) v_printf(4,"none\n"); else v_printf(4,"\n");
     rac.write_bit(false);
     const ColorRanges* ranges = rangesList.back();
-    grey.clear();
-    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
 
     for (int p = 0; p < ranges->numPlanes(); p++) {
       v_printf(7,"Plane %i: %i..%i\n",p,ranges->min(p),ranges->max(p));

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -35,6 +35,7 @@ template<typename RAC> void static write_name(RAC& rac, std::string desc, uint8_
 // FRA = true: image has FRA plane (animation with lookback)
 template<typename IO, typename Rac, typename Coder>
 void flif_encode_scanlines_inner(IO& io, Rac& rac, std::vector<Coder> &coders, const Images &images, const ColorRanges *ranges) {
+    const std::vector<ColorVal> greys = computeGreys(ranges);
     ColorVal min,max;
     long fs = io.ftell();
     long pixels = images[0].cols()*images[0].rows()*images.size();
@@ -195,14 +196,13 @@ void flif_encode_FLIF2_pass(IO& io, Rac &rac, const Images &images, const ColorR
 
 void flif_encode_FLIF2_interpol_zero_alpha(Images &images, const ColorRanges * ranges, const int beginZL, const int endZL)
 {
-    std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
-    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
+    const std::vector<ColorVal> greys = computeGreys(ranges);
 
     for (Image& image : images) {
      if (image(3,0,0) == 0) {
-       image.set(0,0,0,grey[0]);
-       image.set(1,0,0,grey[1]);
-       image.set(2,0,0,grey[2]);
+       image.set(0,0,0,greys[0]);
+       image.set(1,0,0,greys[1]);
+       image.set(2,0,0,greys[2]);
      }
      for (int i = 0; i < plane_zoomlevels(image, beginZL, endZL); i++) {
       std::pair<int, int> pzl = plane_zoomlevel(image, beginZL, endZL, i);
@@ -232,8 +232,7 @@ void flif_encode_FLIF2_interpol_zero_alpha(Images &images, const ColorRanges * r
 }
 
 void flif_encode_scanlines_interpol_zero_alpha(Images &images, const ColorRanges *ranges){
-    std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
-    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
+    const std::vector<ColorVal> greys = computeGreys(ranges);
 
     int nump = images[0].numPlanes();
     if (nump > 3)
@@ -243,7 +242,7 @@ void flif_encode_scanlines_interpol_zero_alpha(Images &images, const ColorRanges
         for (uint32_t r = 0; r < image.rows(); r++) {
             for (uint32_t c = 0; c < image.cols(); c++) {
                 if (image(3,r,c) == 0) {
-                    image.set(p,r,c, predictScanlines(image,p,r,c, grey[p]));
+                    image.set(p,r,c, predictScanlines(image,p,r,c, greys[p]));
                 }
             }
         }

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -232,6 +232,9 @@ void flif_encode_FLIF2_interpol_zero_alpha(Images &images, const ColorRanges * r
 }
 
 void flif_encode_scanlines_interpol_zero_alpha(Images &images, const ColorRanges *ranges){
+    std::vector<ColorVal> grey; // a pixel with values in the middle of the bounds
+    for (int p = 0; p < ranges->numPlanes(); p++) grey.push_back((ranges->min(p)+ranges->max(p))/2);
+
     int nump = images[0].numPlanes();
     if (nump > 3)
     for (Image& image : images)
@@ -240,7 +243,7 @@ void flif_encode_scanlines_interpol_zero_alpha(Images &images, const ColorRanges
         for (uint32_t r = 0; r < image.rows(); r++) {
             for (uint32_t c = 0; c < image.cols(); c++) {
                 if (image(3,r,c) == 0) {
-                    image.set(p,r,c, predict(image,p,r,c));
+                    image.set(p,r,c, predictScanlines(image,p,r,c, grey[p]));
                 }
             }
         }

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -47,6 +47,7 @@ void flif_encode_scanlines_inner(IO& io, Rac& rac, std::vector<Coder> &coders, c
         if (p>=nump) continue;
         i++;
         if (ranges->min(p) >= ranges->max(p)) continue;
+        const ColorVal minP = ranges->min(p);
         Properties properties((nump>3?NB_PROPERTIES_scanlinesA[p]:NB_PROPERTIES_scanlines[p]));
         v_printf(2,"\r%i%% done [%i/%i] ENC[%ux%u]    ",(int)(100*pixels_done/pixels_todo),i,nump,images[0].cols(),images[0].rows());
         pixels_done += images[0].cols()*images[0].rows();
@@ -58,7 +59,7 @@ void flif_encode_scanlines_inner(IO& io, Rac& rac, std::vector<Coder> &coders, c
               for (uint32_t c = begin; c < end; c++) {
                 if (alphazero && p<3 && image(3,r,c) == 0) continue;
                 if (FRA && p<4 && image(4,r,c) > 0) continue;
-                ColorVal guess = predict_and_calcProps_scanlines(properties,ranges,image,p,r,c,min,max);
+                ColorVal guess = predict_and_calcProps_scanlines(properties,ranges,image,p,r,c,min,max, minP);
                 ColorVal curr = image(p,r,c);
                 assert(p != 3 || curr >= -fr);
                 if (FRA && p==4 && max > fr) max = fr;


### PR DESCRIPTION
My mini benchmark results:

```
                       no-grey   signed IQ
-------------------------------------------
1_webp_ll.flif         78575        78560
2_webp_ll.flif         26591        26648
3_webp_ll.flif        156812       156806
5_webp_ll.flif         97864        98223
clock.flif             22538        22538
kodim07.flif          367234       370916
kodim08.flif          511741       512978
kodim12.flif          391329       391520
kodim13.flif          562924       565589
monkey.flif          1203177      1204173
pyani.flif            577229       583310
spinfox.flif          373800       373747
tea.flif              481203       481870
train.flif           1240191      1265475
watch_by8.flif        172195       172002
------------------------------------------
                     6263403      6304355

```
