### PR TITLE
image_load_rggb(): fix compile warning, (strcmp was not used),

### DIFF
--- a/src/image/image-rggb.cpp
+++ b/src/image/image-rggb.cpp
@@ -119,7 +119,7 @@ bool image_load_rggb(const char *filename, Image& image)
 		/* Px formats can have # comments after first line */
 		t = fgets(buf, PPMREADBUFLEN, fp);
 		if ( t == NULL ) return 1;
-		if ( (t != "\n") && (strncmp(buf, "#", 1) == 0)) {
+		if ( (strcmp(t, "\n") != 0) && (strncmp(buf, "#", 1) == 0)) {
 			if (strlen(comments) != 1) strcat(comments, buf);
 			else strcpy(comments, buf);
 		}


### PR DESCRIPTION
 was:
image/image-rggb.cpp: In function ‘bool image_load_rggb(const char*, Image&)’:
image/image-rggb.cpp:122:14: warning: comparison with string literal results in unspecified behaviour [-Waddress]
   if ( (t != "\n") && (strncmp(buf, "#", 1) == 0)) {
              ^