### PR TITLE
makefile: target 'test' failed on clean repo; make test-interface missed dep

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -82,7 +82,7 @@ clean:
 
 # The targets below are only meant for developers
 
-test-interface: libflif.dbg.so ../tools/test.c
+test-interface: libflif.dbg.so libflif.so ../tools/test.c
 	$(CC) -O0 -ggdb3 -Wall -Ilibrary/ ../tools/test.c -L. -lflif.dbg  -o test-interface
 
 test: flif test-interface


### PR DESCRIPTION
target 'test' failed on clean repo because 'test-interface' target require libflif.so which wouldn't get built on 'make test'.