### PR TITLE
fix for viewflif compiler warning on 64bit

### DIFF
--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -61,7 +61,7 @@ void draw_image() {
 uint32_t progressive_render(int32_t quality, int64_t bytes_read) {
     while (drawing) {SDL_Delay(50);}
     drawing = 1;
-    printf("%lli bytes read, rendering at quality=%.2f%%\n",bytes_read, 0.01*quality);
+    printf("%lli bytes read, rendering at quality=%.2f%%\n",(unsigned long long int) bytes_read, 0.01*quality);
     animation = (flif_decoder_num_images(d) > 1);
     FLIF_IMAGE* image = flif_decoder_get_image(d, 0);
     if (!image) { printf("Error: No decoded image found\n"); return 1; }
@@ -70,7 +70,7 @@ uint32_t progressive_render(int32_t quality, int64_t bytes_read) {
     if (!window) { printf("Error: Could not create window\n"); return 2; }
     SDL_SetWindowSize(window,w,h);
     char title[100];
-    sprintf(title,"%ix%i FLIF image [read %lli bytes, quality=%.2f%%]",w,h,bytes_read, 0.01*quality);
+    sprintf(title,"%ix%i FLIF image [read %lli bytes, quality=%.2f%%]",w,h,(unsigned long long int) bytes_read, 0.01*quality);
     SDL_SetWindowTitle(window,title);
     for (int f = 0; f< flif_decoder_num_images(d); f++) {
         FLIF_IMAGE* image = flif_decoder_get_image(d, f);


### PR DESCRIPTION
Compiling on 64bit gives error, I'm not that great with c++. But this is an attempt to solve it. If it's not the right way to go about it my apologies. I've compiled with no errors on both 32bit and 64bit Archlinux. But I'm not aware of any impact this may have on other platforms.


Here is said error for reference:
```
viewflif.c: In function ‘progressive_render’:
viewflif.c:64:12: warning: format ‘%lli’ expects argument of type ‘long long int’, but argument 2 has type ‘int64_t {aka long int}’ [-Wformat=]
     printf("%lli bytes read, rendering at quality=%.2f%%\n",bytes_read, 0.01*quality);
            ^
viewflif.c:73:19: warning: format ‘%lli’ expects argument of type ‘long long int’, but argument 5 has type ‘int64_t {aka long int}’ [-Wformat=]
     sprintf(title,"%ix%i FLIF image [read %lli bytes, quality=%.2f%%]",w,h,bytes_read, 0.01*quality);
                   ^
```