### PR TITLE
Reduce virtual function calls for pixel access using templates

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -59,42 +59,7 @@ void initPropRanges_scanlines(Ranges &propRanges, const ColorRanges &ranges, int
 }
 
 ColorVal predict_and_calcProps_scanlines(Properties &properties, const ColorRanges *ranges, const Image &image, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max, const ColorVal fallback) {
-    ColorVal guess;
-    int which = 0;
-    int index=0;
-    if (p < 3) {
-      for (int pp = 0; pp < p; pp++) {
-        properties[index++] = image(pp,r,c);
-      }
-      if (image.numPlanes()>3) properties[index++] = image(3,r,c);
-    }
-    ColorVal left = (c>0 ? image(p,r,c-1) : (r > 0 ? image(p, r-1, c) : fallback));
-    ColorVal top = (r>0 ? image(p,r-1,c) : left);
-    ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : (r > 0 ? top : left));
-    ColorVal gradientTL = left + top - topleft;
-    guess = median3(gradientTL, left, top);
-    ranges->snap(p,properties,min,max,guess);
-    assert(min >= ranges->min(p));
-    assert(max <= ranges->max(p));
-    assert(guess >= min);
-    assert(guess <= max);
-    if (guess == gradientTL) which = 0;
-    else if (guess == left) which = 1;
-    else if (guess == top) which = 2;
-
-    properties[index++] = guess;
-    properties[index++] = which;
-
-    if (c > 0 && r > 0) { properties[index++] = left - topleft; properties[index++] = topleft - top; }
-                 else   { properties[index++] = 0; properties[index++] = 0;  }
-
-    if (c+1 < image.cols() && r > 0) properties[index++] = top - image(p,r-1,c+1); // top - topright
-                 else   properties[index++] = 0;
-    if (r > 1) properties[index++] = image(p,r-2,c)-top;    // toptop - top
-         else properties[index++] = 0;
-    if (c > 1) properties[index++] = image(p,r,c-2)-left;    // leftleft - left
-         else properties[index++] = 0;
-    return guess;
+    return predict_and_calcProps_scanlines_plane(properties,ranges,image,image.getPlane(p),p,r,c,min,max, fallback);
 }
 
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -93,7 +93,7 @@ void initPropRanges(Ranges &propRanges, const ColorRanges &ranges, int p) {
 // Actual prediction. Also sets properties. Property vector should already have the right size before calling this.
 ColorVal predict_and_calcProps(Properties &properties, const ColorRanges *ranges, const Image &image, const int z, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max) ATTRIBUTE_HOT;
 ColorVal predict_and_calcProps(Properties &properties, const ColorRanges *ranges, const Image &image, const int z, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max) {
-    predict_and_calcProps_plane(properties,ranges,image,image.getPlane(p),z,p,r,c,min,max);
+    return predict_and_calcProps_plane(properties,ranges,image,image.getPlane(p),z,p,r,c,min,max);
 }
 
 int plane_zoomlevels(const Image &image, const int beginZL, const int endZL) {

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -181,7 +181,9 @@ inline ColorVal predict(const Image &image, int z, int p, uint32_t r, uint32_t c
 
 // Actual prediction. Also sets properties. Property vector should already have the right size before calling this.
 template <typename plane_t>
-ColorVal predict_and_calcProps_plane(Properties &properties, const ColorRanges *ranges, const Image &image, const plane_t &plane, const int z, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max) ATTRIBUTE_HOT{
+ColorVal predict_and_calcProps_plane(Properties &properties, const ColorRanges *ranges, const Image &image, const plane_t &plane, const int z, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max) ATTRIBUTE_HOT;
+template <typename plane_t>
+ColorVal predict_and_calcProps_plane(Properties &properties, const ColorRanges *ranges, const Image &image, const plane_t &plane, const int z, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max) {
     ColorVal guess;
     int which = 0;
     int index = 0;

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -93,13 +93,59 @@ template<typename I> I inline median3(I a, I b, I c) {
     }
 }
 
+template <typename plane_t>
+ColorVal predict_and_calcProps_scanlines_plane(Properties &properties, const ColorRanges *ranges, const Image &image, const plane_t &plane, const int p, const uint32_t r, const uint32_t c, ColorVal &min, ColorVal &max, const ColorVal fallback) {
+    ColorVal guess;
+    int which = 0;
+    int index=0;
+    if (p < 3) {
+        for (int pp = 0; pp < p; pp++) {
+            properties[index++] = image(pp,r,c);
+        }
+        if (image.numPlanes()>3) properties[index++] = image(3,r,c);
+    }
+    ColorVal left = (c>0 ? plane.get(r,c-1) : (r > 0 ? plane.get(r-1, c) : fallback));
+    ColorVal top = (r>0 ? plane.get(r-1,c) : left);
+    ColorVal topleft = (r>0 && c>0 ? plane.get(r-1,c-1) : (r > 0 ? top : left));
+    ColorVal gradientTL = left + top - topleft;
+    guess = median3(gradientTL, left, top);
+    ranges->snap(p,properties,min,max,guess);
+    assert(min >= ranges->min(p));
+    assert(max <= ranges->max(p));
+    assert(guess >= min);
+    assert(guess <= max);
+    if (guess == gradientTL) which = 0;
+    else if (guess == left) which = 1;
+    else if (guess == top) which = 2;
+
+    properties[index++] = guess;
+    properties[index++] = which;
+
+    if (c > 0 && r > 0) { properties[index++] = left - topleft; properties[index++] = topleft - top; }
+    else   { properties[index++] = 0; properties[index++] = 0;  }
+
+    if (c+1 < image.cols() && r > 0) properties[index++] = top - plane.get(r-1,c+1); // top - topright
+    else   properties[index++] = 0;
+    if (r > 1) properties[index++] = plane.get(r-2,c)-top;    // toptop - top
+    else properties[index++] = 0;
+    if (c > 1) properties[index++] = plane.get(r,c-2)-left;    // leftleft - left
+    else properties[index++] = 0;
+    return guess;
+}
+
 // Prediction used for interpolation / alpha=0 pixels. Does not have to be the same as the guess used for encoding/decoding.
-inline ColorVal predictScanlines(const Image &image, int p, uint32_t r, uint32_t c, ColorVal grey) {
-    ColorVal left = (c>0 ? image(p,r,c-1) : (r > 0 ? image(p, r-1, c) : grey));
-    ColorVal top = (r>0 ? image(p,r-1,c) : left);
-    ColorVal topleft = (r>0 && c>0 ? image(p,r-1,c-1) : top);
+template <typename plane_t>
+inline ColorVal predictScanlines_plane(const plane_t &plane, uint32_t r, uint32_t c, ColorVal grey) {
+    ColorVal left = (c>0 ? plane.get(r,c-1) : (r > 0 ? plane.get(r-1, c) : grey));
+    ColorVal top = (r>0 ? plane.get(r-1,c) : left);
+    ColorVal topleft = (r>0 && c>0 ? plane.get(r-1,c-1) : top);
     ColorVal gradientTL = left + top - topleft;
     return median3(gradientTL, left, top);
+}
+
+// Prediction used for interpolation / alpha=0 pixels. Does not have to be the same as the guess used for encoding/decoding.
+inline ColorVal predictScanlines(const Image &image, int p, uint32_t r, uint32_t c, ColorVal grey) {
+    return predictScanlines_plane(image.getPlane(p),r,c,grey);
 }
 
 // Prediction used for interpolation / alpha=0 pixels. Does not have to be the same as the guess used for encoding/decoding.

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -251,8 +251,9 @@ void flif_decode_plane_zoomlevel_horizontal(plane_t &plane, Coder &coder, Images
                 if (alpha.get(z,r,c) == 0) plane.set(z,r,c, predict_plane_horizontal(plane,z,p,r,c, image.rows(z)));
         }
         else if (p != 4) {
-            copy_row_range(plane, images[fr - 1].getPlane(p), r, 0, begin, image.zoom_colpixelsize(z));
-            copy_row_range(plane, images[fr - 1].getPlane(p), r, end, image.cols(z), image.zoom_colpixelsize(z));
+            const uint32_t cs = image.zoom_colpixelsize(z), rs = image.zoom_rowpixelsize(z);
+            copy_row_range(plane, images[fr - 1].getPlane(p), rs*r, cs*0, cs*begin, cs);
+            copy_row_range(plane, images[fr - 1].getPlane(p), rs*r, cs*end, cs*image.cols(z), cs);
         }
     } else {
         if (image.numPlanes()>3 && p<3) {begin=0; end=image.cols(z);}
@@ -285,8 +286,9 @@ void flif_decode_plane_zoomlevel_vertical(plane_t &plane, Coder &coder, Images &
                 if (alpha.get(z, r, c) == 0) plane.set(z, r, c, predict_plane_vertical(plane, z, p, r, c, image.cols(z)));
         }
         else if (p != 4) {
-            copy_row_range(plane, images[fr - 1].getPlane(p), r, 1, begin, image.zoom_colpixelsize(z)*2);
-            copy_row_range(plane, images[fr - 1].getPlane(p), r, end, image.cols(z), image.zoom_colpixelsize(z)*2);
+            const uint32_t cs = image.zoom_colpixelsize(z), rs = image.zoom_rowpixelsize(z);
+            copy_row_range(plane, images[fr - 1].getPlane(p), rs*r, cs*1, cs*begin, cs*2);
+            copy_row_range(plane, images[fr - 1].getPlane(p), rs*r, cs*end, cs*image.cols(z), cs*2);
         }
     } else {
         if (image.numPlanes()>3 && p<3) {begin=1; end=image.cols(z);}

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -47,14 +47,25 @@ std::unique_ptr<T> make_unique(Args &&... args)
 
 struct PlaneVisitor;
 
+
 class GeneralPlane {
 public:
     virtual void set(const uint32_t r, const uint32_t c, const ColorVal x) =0;
     virtual ColorVal get(const uint32_t r, const uint32_t c) const =0;
     virtual bool is_constant() const { return false; }
     virtual ~GeneralPlane() { }
+    virtual void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) =0;
+    virtual ColorVal get(const int z, const uint32_t r, const uint32_t c) =0;
+    virtual void normalize_scale() {}
     virtual void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const =0;
     virtual void accept_visitor(PlaneVisitor &v) =0;
+    // access pixel by zoomlevel coordinate
+    uint32_t zoom_rowpixelsize(int zoomlevel) const {
+        return 1<<((zoomlevel+1)/2);
+    }
+    uint32_t zoom_colpixelsize(int zoomlevel) const {
+        return 1<<((zoomlevel)/2);
+    }
 };
 
 template <typename> class Plane;
@@ -69,24 +80,35 @@ struct PlaneVisitor {
     virtual ~PlaneVisitor() {}
 };
 
+#define SCALED(x) (((x-1)>>scale)+1)
 template <typename pixel_t> class Plane final : public GeneralPlane {
     std::valarray<pixel_t> data;
     const uint32_t width, height;
+    int s;
 public:
-    Plane(uint32_t w, uint32_t h, ColorVal color=0) : data(color, w*h), width(w), height(h) { }
+    Plane(uint32_t w, uint32_t h, ColorVal color=0, int scale = 0) : s(scale), data(color, SCALED(w)*SCALED(h)), width(SCALED(w)), height(SCALED(h)) { }
     void clear() {
         data.clear();
     }
     void set(const uint32_t r, const uint32_t c, const ColorVal x) {
-        assert(r<height); assert(c<width);
-        data[r*width + c] = x;
+        const uint32_t sr = r>>s, sc = c>>s;
+        assert(sr<height); assert(sc<width);
+        data[sr*width + sc] = x;
     }
     ColorVal get(const uint32_t r, const uint32_t c) const ATTRIBUTE_HOT {
 //        if (r >= height || r < 0 || c >= width || c < 0) {printf("OUT OF RANGE!\n"); return 0;}
-        assert(r<height); assert(c<width);
-        return data[r*width + c];
+        const uint32_t sr = r>>s, sc = c>>s;
+        assert(sr<height); assert(sc<width);
+        return data[sr*width + sc];
     }
 
+    void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) {
+        set(r*zoom_rowpixelsize(z),c*zoom_colpixelsize(z),x);
+    }
+    ColorVal get(const int z, const uint32_t r, const uint32_t c) {
+        return get(r*zoom_rowpixelsize(z),c*zoom_colpixelsize(z));
+    }
+    void normalize_scale() { s = 0; }
     void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const{
         for(uint32_t c = begin; c < end; c+= stride) assert(x == get(r,c));
     }
@@ -108,6 +130,12 @@ public:
     }
     bool is_constant() const { return true; }
 
+    void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) {
+        assert(x == color);
+    }
+    ColorVal get(const int z, const uint32_t r, const uint32_t c) {
+        return color;
+    }
     void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const{
         assert(x == color);
     }
@@ -129,7 +157,7 @@ void copy_row_range(plane_t &plane, const GeneralPlane &other, const uint32_t r,
     }
 }
 
-#define SCALED(x) (((x-1)>>scale)+1)
+
 class Image {
     std::unique_ptr<GeneralPlane> planes[5];
     uint32_t width, height;
@@ -166,19 +194,19 @@ class Image {
       {
       int p=num;
       if (depth <= 8) {
-        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height)); // R,Y
-        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_16>>(SCALED(width), SCALED(height)); // G,I
-        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_16>>(SCALED(width), SCALED(height)); // B,Q
-        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height)); // A
+        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale); // R,Y
+        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_16>>(width, height, 0, scale); // G,I
+        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_16>>(width, height, 0, scale); // B,Q
+        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale); // A
 #ifdef SUPPORT_HDR
       } else {
-        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_16u>>(SCALED(width), SCALED(height)); // R,Y
-        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_32>>(SCALED(width), SCALED(height)); // G,I
-        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_32>>(SCALED(width), SCALED(height)); // B,Q
-        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_16u>>(SCALED(width), SCALED(height)); // A
+        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_16u>>(width, height, 0, scale); // R,Y
+        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_32>>(width, height, 0, scale); // G,I
+        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_32>>(width, height, 0, scale); // B,Q
+        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_16u>>(width, height, 0, scale); // A
 #endif
       }
-      if (p>4) planes[4] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height)); // FRA
+      if (p>4) planes[4] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale); // FRA
       }
       for(int p=0; p<num; p++)
           for (uint32_t r=0; r<height; r++)
@@ -276,19 +304,19 @@ public:
       clear();
       try {
       if (depth <= 8) {
-        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height)); // R,Y
-        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_16>>(SCALED(width), SCALED(height)); // G,I
-        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_16>>(SCALED(width), SCALED(height)); // B,Q
-        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height)); // A
+        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale); // R,Y
+        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_16>>(width, height, 0, scale); // G,I
+        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_16>>(width, height, 0, scale); // B,Q
+        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale); // A
 #ifdef SUPPORT_HDR
       } else {
-        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_16u>>(SCALED(width), SCALED(height)); // R,Y
-        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_32>>(SCALED(width), SCALED(height)); // G,I
-        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_32>>(SCALED(width), SCALED(height)); // B,Q
-        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_16u>>(SCALED(width), SCALED(height)); // A
+        if (p>0) planes[0] = make_unique<Plane<ColorVal_intern_16u>>(width, height, 0, scale); // R,Y
+        if (p>1) planes[1] = make_unique<Plane<ColorVal_intern_32>>(width, height, 0, scale); // G,I
+        if (p>2) planes[2] = make_unique<Plane<ColorVal_intern_32>>(width, height, 0, scale); // B,Q
+        if (p>3) planes[3] = make_unique<Plane<ColorVal_intern_16u>>(width, height, 0, scale); // A
 #endif
       }
-      if (p>4) planes[4] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height)); // FRA
+      if (p>4) planes[4] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale); // FRA
       }
       catch (std::bad_alloc& ba) {
         e_printf("Error: could not allocate enough memory for image data.\n");
@@ -313,6 +341,8 @@ public:
       col_begin.resize(height,0);
       col_end.clear();
       col_end.resize(height,width);
+      for(int p = 0; p < num; p++)
+          planes[p]->normalize_scale();
     }
 
     void clear() {
@@ -367,16 +397,16 @@ public:
       ColorVal val = operator()(p,0,0);
       planes[p].reset(nullptr);
       if (depth <= 8) {
-        if (p==0) planes[0] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height), val); // R,Y
-        if (p==1) planes[1] = make_unique<Plane<ColorVal_intern_16>>(SCALED(width), SCALED(height), val); // G,I
-        if (p==2) planes[2] = make_unique<Plane<ColorVal_intern_16>>(SCALED(width), SCALED(height), val); // B,Q
-        if (p==3) planes[3] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height), val); // A
+        if (p==0) planes[0] = make_unique<Plane<ColorVal_intern_8>>(width, height, val, scale); // R,Y
+        if (p==1) planes[1] = make_unique<Plane<ColorVal_intern_16>>(width, height, val, scale); // G,I
+        if (p==2) planes[2] = make_unique<Plane<ColorVal_intern_16>>(width, height, val, scale); // B,Q
+        if (p==3) planes[3] = make_unique<Plane<ColorVal_intern_8>>(width, height, val, scale); // A
 #ifdef SUPPORT_HDR
       } else {
-        if (p==0) planes[0] = make_unique<Plane<ColorVal_intern_16u>>(SCALED(width), SCALED(height), val); // R,Y
-        if (p==1) planes[1] = make_unique<Plane<ColorVal_intern_32>>(SCALED(width), SCALED(height), val); // G,I
-        if (p==2) planes[2] = make_unique<Plane<ColorVal_intern_32>>(SCALED(width), SCALED(height), val); // B,Q
-        if (p==3) planes[3] = make_unique<Plane<ColorVal_intern_16u>>(SCALED(width), SCALED(height), val); // A
+        if (p==0) planes[0] = make_unique<Plane<ColorVal_intern_16u>>(width, height, val, scale); // R,Y
+        if (p==1) planes[1] = make_unique<Plane<ColorVal_intern_32>>(width, height, val, scale); // G,I
+        if (p==2) planes[2] = make_unique<Plane<ColorVal_intern_32>>(width, height, val, scale); // B,Q
+        if (p==3) planes[3] = make_unique<Plane<ColorVal_intern_16u>>(width, height, val, scale); // A
 #endif
       }
     }
@@ -404,7 +434,7 @@ public:
     void ensure_frame_lookbacks() {
         if (num < 5) {
             ensure_alpha();
-            planes[4] = make_unique<Plane<ColorVal_intern_8>>(SCALED(width), SCALED(height));
+            planes[4] = make_unique<Plane<ColorVal_intern_8>>(width, height, 0, scale);
             num=5;
         }
     }
@@ -418,12 +448,12 @@ public:
     ColorVal operator()(const int p, const uint32_t r, const uint32_t c) const ATTRIBUTE_HOT {
       assert(p>=0);
       assert(p<num);
-      return planes[p]->get(r>>scale,c>>scale);
+      return planes[p]->get(r,c);
     }
     void set(int p, uint32_t r, uint32_t c, ColorVal x) {
       assert(p>=0);
       assert(p<num);
-      planes[p]->set(r>>scale,c>>scale,x);
+      planes[p]->set(r,c,x);
     }
 
     int numPlanes() const { return num; }
@@ -452,14 +482,14 @@ public:
         return z;
     }
     ColorVal operator()(int p, int z, uint32_t rz, uint32_t cz) const ATTRIBUTE_HOT {
-        uint32_t r = rz*zoom_rowpixelsize(z);
-        uint32_t c = cz*zoom_colpixelsize(z);
-        return operator()(p,r,c);
+        assert(p>=0);
+        assert(p<num);
+        return planes[p]->get(z,rz,cz);
     }
     void set(int p, int z, uint32_t rz, uint32_t cz, ColorVal x) {
-        uint32_t r = rz*zoom_rowpixelsize(z);
-        uint32_t c = cz*zoom_colpixelsize(z);
-        set(p,r,c,x);
+        assert(p>=0);
+        assert(p<num);
+        planes[p]->set(z,rz,cz,x);
     }
 
     GeneralPlane& getPlane(int p) {

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -86,7 +86,7 @@ template <typename pixel_t> class Plane final : public GeneralPlane {
     const uint32_t width, height;
     int s;
 public:
-    Plane(uint32_t w = 0, uint32_t h = 0, ColorVal color=0, int scale = 0) : s(scale), data(color, SCALED(w)*SCALED(h)), width(SCALED(w)), height(SCALED(h)) { }
+    Plane(uint32_t w, uint32_t h, ColorVal color=0, int scale = 0) : s(scale), data(color, SCALED(w)*SCALED(h)), width(SCALED(w)), height(SCALED(h)) { }
     void clear() {
         data.clear();
     }
@@ -121,7 +121,7 @@ public:
 class ConstantPlane final : public GeneralPlane {
     ColorVal color;
 public:
-    ConstantPlane(ColorVal c = 0) : color(c) {}
+    ConstantPlane(ColorVal c) : color(c) {}
     void set(const uint32_t r, const uint32_t c, const ColorVal x) {
         assert(x == color);
     }


### PR DESCRIPTION
Every call to get and set in the decode loops is now done through a templated reference type except for pixels in other other frames and non-alpha planes. This should allow them to be inlined and further optimized by the compiler. Improves #89
It should also pass the build test this time