### PR TITLE
Use override when possible

### DIFF
--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -93,11 +93,11 @@ struct scanline_plane_decoder: public PlaneVisitor {
     scanline_plane_decoder(Coder &c, Images &i, const ColorRanges *ra, Properties &prop, const GeneralPlane &al, const int pl, const int f, const uint32_t row, const ColorVal g, const ColorVal m, const bool az, const bool fra) :
         coder(c), images(i), ranges(ra), properties(prop), alpha(static_cast<const alpha_t&>(al)), p(pl), fr(f), r(row), grey(g), minP(m), alphazero(az), FRA(fra) {}
 
-    void visit(Plane<ColorVal_intern_8>   &plane) {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_16>  &plane) {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_16u> &plane) {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_32>  &plane) {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
-    void visit(ConstantPlane              &plane) {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_8>   &plane) override {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_16>  &plane) override {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_16u> &plane) override {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_32>  &plane) override {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
+    void visit(ConstantPlane              &plane) override {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
 };
 
 template<typename IO, typename Rac, typename Coder>
@@ -309,11 +309,11 @@ struct horizontal_plane_decoder: public PlaneVisitor {
     horizontal_plane_decoder(Coder &c, Images &i, const ColorRanges *ra, Properties &prop,const GeneralPlane &al,  const int pl, const int zl, const int f, const uint32_t row, const bool az, const bool fra) :
         coder(c), images(i), ranges(ra), properties(prop), alpha(static_cast<const alpha_t&>(al)), p(pl), z(zl), fr(f), r(row), alphazero(az), FRA(fra) {}
 
-    void visit(Plane<ColorVal_intern_8>   &plane) {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_16>  &plane) {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_16u> &plane) {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_32>  &plane) {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(ConstantPlane              &plane) {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_8>   &plane) override {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_16>  &plane) override {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_16u> &plane) override {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_32>  &plane) override {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(ConstantPlane              &plane) override {flif_decode_plane_zoomlevel_horizontal(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
 };
 
 //TODO use tuples or something to make this less ugly/more generic
@@ -323,11 +323,11 @@ struct vertical_plane_decoder: public PlaneVisitor {
     vertical_plane_decoder(Coder &c, Images &i, const ColorRanges *ra, Properties &prop, const GeneralPlane &al, const int pl, const int zl, const int f, const uint32_t row, const bool az, const bool fra) :
         coder(c), images(i), ranges(ra), properties(prop), alpha(static_cast<const alpha_t&>(al)), p(pl), z(zl), fr(f), r(row), alphazero(az), FRA(fra) {}
 
-    void visit(Plane<ColorVal_intern_8>   &plane) {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_16>  &plane) {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_16u> &plane) {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(Plane<ColorVal_intern_32>  &plane) {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
-    void visit(ConstantPlane              &plane) {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_8>   &plane) override {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_16>  &plane) override {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_16u> &plane) override {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(Plane<ColorVal_intern_32>  &plane) override {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
+    void visit(ConstantPlane              &plane) override {flif_decode_plane_zoomlevel_vertical(plane,coder,images,ranges,alpha,properties,p,z,fr,r,alphazero,FRA);}
 };
 
 template<typename IO, typename Rac, typename Coder>

--- a/src/image/color_range.hpp
+++ b/src/image/color_range.hpp
@@ -35,9 +35,9 @@ protected:
 
 public:
     StaticColorRanges(StaticColorRangeList r) : ranges(r) {}
-    int numPlanes() const { return ranges.size(); }
-    ColorVal min(int p) const { if (p >= numPlanes()) return 0; assert(p<numPlanes()); return ranges[p].first; }
-    ColorVal max(int p) const { if (p >= numPlanes()) return 0; assert(p<numPlanes()); return ranges[p].second; }
+    int numPlanes() const override { return ranges.size(); }
+    ColorVal min(int p) const override { if (p >= numPlanes()) return 0; assert(p<numPlanes()); return ranges[p].first; }
+    ColorVal max(int p) const override { if (p >= numPlanes()) return 0; assert(p<numPlanes()); return ranges[p].second; }
 };
 
 const ColorRanges *getRanges(const Image &image);
@@ -48,11 +48,11 @@ protected:
 public:
     DupColorRanges(const ColorRanges *rangesIn) : ranges(rangesIn) {}
 
-    int numPlanes() const { return ranges->numPlanes(); }
-    ColorVal min(int p) const { return ranges->min(p); }
-    ColorVal max(int p) const { return ranges->max(p); }
-    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const { ranges->minmax(p,pp,minv,maxv); }
-    bool isStatic() const { return ranges->isStatic(); }
+    int numPlanes() const override { return ranges->numPlanes(); }
+    ColorVal min(int p) const override { return ranges->min(p); }
+    ColorVal max(int p) const override { return ranges->max(p); }
+    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const override { ranges->minmax(p,pp,minv,maxv); }
+    bool isStatic() const override { return ranges->isStatic(); }
 };
 
 const ColorRanges *dupRanges(const ColorRanges *ranges);

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -113,7 +113,7 @@ public:
     void clear() {
         data.clear();
     }
-    void set(const uint32_t r, const uint32_t c, const ColorVal x) {
+    void set(const uint32_t r, const uint32_t c, const ColorVal x) override {
         const uint32_t sr = r>>s, sc = c>>s;
         assert(sr<height); assert(sc<width);
         data[sr*width + sc] = x;
@@ -129,7 +129,7 @@ public:
         FourColorVals x {data[pos], data[pos+1], data[pos+2], data[pos+3]};
         return x;
     }
-    void set4(const uint32_t pos, const FourColorVals x) {
+    void set4(const uint32_t pos, const FourColorVals x) override {
         data[pos]=x[0];
         data[pos+1]=x[1];
         data[pos+2]=x[2];
@@ -140,7 +140,7 @@ public:
                           (int16_t)data[pos+4], (int16_t)data[pos+5], (int16_t)data[pos+6], (int16_t)data[pos+7]};
         return x;
     }
-    void set8(const uint32_t pos, const EightColorVals x) {
+    void set8(const uint32_t pos, const EightColorVals x) override {
         data[pos]=x[0];
         data[pos+1]=x[1];
         data[pos+2]=x[2];
@@ -151,18 +151,18 @@ public:
         data[pos+7]=x[7];
     }
 #endif
-    void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) {
+    void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) override {
         set(r*zoom_rowpixelsize(z),c*zoom_colpixelsize(z),x);
     }
-    ColorVal get(const int z, const uint32_t r, const uint32_t c) const {
+    ColorVal get(const int z, const uint32_t r, const uint32_t c) const override {
         return get(r*zoom_rowpixelsize(z),c*zoom_colpixelsize(z));
     }
-    void normalize_scale() { s = 0; }
-    void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const{
+    void normalize_scale() override { s = 0; }
+    void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const override {
         for(uint32_t c = begin; c < end; c+= stride) assert(x == get(r,c));
     }
 
-    void accept_visitor(PlaneVisitor &v) {
+    void accept_visitor(PlaneVisitor &v) override {
         v.visit(*this);
     }
 };
@@ -171,10 +171,10 @@ class ConstantPlane final : public GeneralPlane {
     ColorVal color;
 public:
     ConstantPlane(ColorVal c) : color(c) {}
-    void set(const uint32_t r, const uint32_t c, const ColorVal x) {
+    void set(const uint32_t r, const uint32_t c, const ColorVal x) override {
         assert(x == color);
     }
-    ColorVal get(const uint32_t r, const uint32_t c) const {
+    ColorVal get(const uint32_t r, const uint32_t c) const override {
         return color;
     }
 #ifdef USE_SIMD
@@ -182,7 +182,7 @@ public:
         FourColorVals x {color,color,color,color};
         return x;
     }
-    void set4(const uint32_t pos, const FourColorVals x) {
+    void set4(const uint32_t pos, const FourColorVals x) override {
         assert(x[0] == color);
         assert(x[1] == color);
         assert(x[2] == color);
@@ -193,7 +193,7 @@ public:
         EightColorVals x {c,c,c,c,c,c,c,c};
         return x;
     }
-    void set8(const uint32_t pos, const EightColorVals x) {
+    void set8(const uint32_t pos, const EightColorVals x) override {
         assert(x[0] == color);
         assert(x[1] == color);
         assert(x[2] == color);
@@ -204,19 +204,19 @@ public:
         assert(x[7] == color);
     }
 #endif
-    bool is_constant() const { return true; }
+    bool is_constant() const override { return true; }
 
-    void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) {
+    void set(const int z, const uint32_t r, const uint32_t c, const ColorVal x) override {
         assert(x == color);
     }
-    ColorVal get(const int z, const uint32_t r, const uint32_t c) const {
+    ColorVal get(const int z, const uint32_t r, const uint32_t c) const override {
         return color;
     }
-    void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const{
+    void check_equal(const ColorVal x, const uint32_t r, const uint32_t begin, const uint32_t end, const uint32_t stride) const override {
         assert(x == color);
     }
 
-    void accept_visitor(PlaneVisitor &v) {
+    void accept_visitor(PlaneVisitor &v) override {
         v.visit(*this);
     }
 };

--- a/src/transform/bounds.hpp
+++ b/src/transform/bounds.hpp
@@ -29,11 +29,11 @@ protected:
     const ColorRanges *ranges;
 public:
     ColorRangesBounds(const std::vector<std::pair<ColorVal, ColorVal> > &boundsIn, const ColorRanges *rangesIn) : bounds(boundsIn), ranges(rangesIn) {}
-    bool isStatic() const { return false; }
-    int numPlanes() const { return bounds.size(); }
-    ColorVal min(int p) const { assert(p<numPlanes()); return std::max(ranges->min(p), bounds[p].first); }
-    ColorVal max(int p) const { assert(p<numPlanes()); return std::min(ranges->max(p), bounds[p].second); }
-    void snap(const int p, const prevPlanes &pp, ColorVal &min, ColorVal &max, ColorVal &v) const {
+    bool isStatic() const override { return false; }
+    int numPlanes() const override { return bounds.size(); }
+    ColorVal min(int p) const override { assert(p<numPlanes()); return std::max(ranges->min(p), bounds[p].first); }
+    ColorVal max(int p) const override { assert(p<numPlanes()); return std::min(ranges->max(p), bounds[p].second); }
+    void snap(const int p, const prevPlanes &pp, ColorVal &min, ColorVal &max, ColorVal &v) const override {
         if (p==0 || p==3) { min=bounds[p].first; max=bounds[p].second; } // optimization for special case
         else ranges->snap(p,pp,min,max,v);
         if (min < bounds[p].first) min=bounds[p].first;
@@ -46,7 +46,7 @@ public:
         if(v>max) v=max;
         if(v<min) v=min;
     }
-    void minmax(const int p, const prevPlanes &pp, ColorVal &min, ColorVal &max) const {
+    void minmax(const int p, const prevPlanes &pp, ColorVal &min, ColorVal &max) const override {
         assert(p<numPlanes());
         if (p==0 || p==3) { min=bounds[p].first; max=bounds[p].second; return; } // optimization for special case
         ranges->minmax(p, pp, min, max);
@@ -67,9 +67,9 @@ class TransformBounds : public Transform<IO> {
 protected:
     std::vector<std::pair<ColorVal, ColorVal> > bounds;
 
-    bool undo_redo_during_decode() { return false; }
+    bool undo_redo_during_decode() override { return false; }
 
-    const ColorRanges *meta(Images&, const ColorRanges *srcRanges) {
+    const ColorRanges *meta(Images&, const ColorRanges *srcRanges) override {
         if (srcRanges->isStatic()) {
             return new StaticColorRanges(bounds);
         } else {
@@ -77,7 +77,7 @@ protected:
         }
     }
 
-    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) override {
         SimpleSymbolCoder<SimpleBitChance, RacIn<IO>, 18> coder(rac);
         bounds.clear();
         for (int p=0; p<srcRanges->numPlanes(); p++) {
@@ -95,7 +95,7 @@ protected:
     }
 
 #ifdef HAS_ENCODER
-    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const override {
         SimpleSymbolCoder<SimpleBitChance, RacOut<IO>, 18> coder(rac);
         for (int p=0; p<srcRanges->numPlanes(); p++) {
             ColorVal min = bounds[p].first;
@@ -108,7 +108,7 @@ protected:
         }
     }
 
-    bool process(const ColorRanges *srcRanges, const Images &images) {
+    bool process(const ColorRanges *srcRanges, const Images &images) override {
         bounds.clear();
         bool trivialbounds=true;
         int nump=srcRanges->numPlanes();

--- a/src/transform/colorbuckets.hpp
+++ b/src/transform/colorbuckets.hpp
@@ -272,18 +272,18 @@ public:
     ~ColorRangesCB() {
         delete buckets;
     }
-    bool isStatic() const { return false; }
-    int numPlanes() const { return ranges->numPlanes(); }
-    ColorVal min(int p) const { return ranges->min(p); }
-    ColorVal max(int p) const { return ranges->max(p); }
-    void snap(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv, ColorVal &v) const {
+    bool isStatic() const override { return false; }
+    int numPlanes() const override { return ranges->numPlanes(); }
+    ColorVal min(int p) const override { return ranges->min(p); }
+    ColorVal max(int p) const override { return ranges->max(p); }
+    void snap(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv, ColorVal &v) const override {
         const ColorBucket& b = bucket(p,pp);
         minv=b.min;
         maxv=b.max;
         if (b.min > b.max) { e_printf("Corruption detected!\n"); minv=v=min(p); maxv=max(p); return; } // this should only happen on malicious input files
         v=b.snapColor(v);
     }
-    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const {
+    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const override {
         const ColorBucket& b = bucket(p,pp);
         minv=b.min;
         maxv=b.max;
@@ -305,7 +305,7 @@ protected:
     ~TransformCB() {if (!really_used) delete cb;}
     bool undo_redo_during_decode() { return false; }
 
-    const ColorRanges* meta(Images&, const ColorRanges *srcRanges) {
+    const ColorRanges* meta(Images&, const ColorRanges *srcRanges) override {
 //        cb->print();
         really_used = true;
 
@@ -339,7 +339,7 @@ protected:
 
         return new ColorRangesCB(srcRanges, cb);
     }
-    bool init(const ColorRanges *srcRanges) {
+    bool init(const ColorRanges *srcRanges) override {
         cb = NULL;
         really_used = false;
         if(srcRanges->numPlanes() < 3) return false;
@@ -416,7 +416,7 @@ protected:
         }
         return b;
     }
-    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coder(rac);
         prevPlanes pixelL, pixelU;
         cb->bucket0 = load_bucket(coder, srcRanges, 0, pixelL, pixelU);
@@ -477,7 +477,7 @@ protected:
            }
         }
     }
-    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coder(rac);
 //        printf("Saving Y Color Bucket: ");
         prevPlanes pixelL, pixelU;
@@ -510,7 +510,7 @@ protected:
         }
     }
 
-    bool process(const ColorRanges *srcRanges, const Images &images) {
+    bool process(const ColorRanges *srcRanges, const Images &images) override {
             std::vector<ColorVal> pixel(images[0].numPlanes());
             // fill buckets
             for (const Image& image : images)

--- a/src/transform/framedup.hpp
+++ b/src/transform/framedup.hpp
@@ -32,8 +32,8 @@ protected:
     std::vector<int> seen_before;
     uint32_t nb;
 
-    bool undo_redo_during_decode() { return false; }
-    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) {
+    bool undo_redo_during_decode() override { return false; }
+    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) override {
         for (unsigned int fr=0; fr<images.size(); fr++) {
             Image& image = images[fr];
             image.seen_before = seen_before[fr];
@@ -41,9 +41,9 @@ protected:
         return new DupColorRanges(srcRanges);
     }
 
-    void configure(const int setting) { nb=setting; }
+    void configure(const int setting) override { nb=setting; }
 
-    bool load(const ColorRanges *, RacIn<IO> &rac) {
+    bool load(const ColorRanges *, RacIn<IO> &rac) override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coder(rac);
         seen_before.clear();
         seen_before.push_back(-1);
@@ -53,14 +53,14 @@ protected:
     }
 
 #ifdef HAS_ENCODER
-    void save(const ColorRanges *, RacOut<IO> &rac) const {
+    void save(const ColorRanges *, RacOut<IO> &rac) const override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coder(rac);
         assert(nb == seen_before.size());
         for (unsigned int i=1; i<seen_before.size(); i++) coder.write_int(-1,i-1,seen_before[i]);
         int count=0; for(int i : seen_before) { if(i>=0) count++; } v_printf(5,"[%i]",count);
     }
 
-    bool process(const ColorRanges *srcRanges, const Images &images) {
+    bool process(const ColorRanges *srcRanges, const Images &images) override {
         int np=srcRanges->numPlanes();
         nb = images.size();
         seen_before.clear();

--- a/src/transform/frameshape.hpp
+++ b/src/transform/frameshape.hpp
@@ -33,9 +33,9 @@ protected:
     uint32_t cols;
     uint32_t nb;
 
-    bool undo_redo_during_decode() { return false; }
+    bool undo_redo_during_decode() override { return false; }
 
-    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) {
+    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) override {
         uint32_t pos=0;
         for (unsigned int fr=1; fr<images.size(); fr++) {
             Image& image = images[fr];
@@ -50,9 +50,9 @@ protected:
         return new DupColorRanges(srcRanges);
     }
 
-    void configure(const int setting) { if (nb==0) nb=setting; else cols=setting; } // ok this is dirty
+    void configure(const int setting) override { if (nb==0) nb=setting; else cols=setting; } // ok this is dirty
 
-    bool load(const ColorRanges *, RacIn<IO> &rac) {
+    bool load(const ColorRanges *, RacIn<IO> &rac) override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coder(rac);
         for (unsigned int i=0; i<nb; i+=1) {b.push_back(coder.read_int(0,cols));}
         for (unsigned int i=0; i<nb; i+=1) {
@@ -66,7 +66,7 @@ protected:
     }
 
 #if HAS_ENCODER
-    void save(const ColorRanges *, RacOut<IO> &rac) const {
+    void save(const ColorRanges *, RacOut<IO> &rac) const override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coder(rac);
         assert(nb == b.size());
         assert(nb == e.size());
@@ -74,7 +74,7 @@ protected:
         for (unsigned int i=0; i<nb; i+=1) { coder.write_int(0,cols-b[i],cols-e[i]); }
     }
 
-    bool process(const ColorRanges *srcRanges, const Images &images) {
+    bool process(const ColorRanges *srcRanges, const Images &images) override {
         if (images.size()<2) return false;
         int np=srcRanges->numPlanes();
         nb = 0;

--- a/src/transform/palette.hpp
+++ b/src/transform/palette.hpp
@@ -34,18 +34,18 @@ protected:
     int nb_colors;
 public:
     ColorRangesPalette(const ColorRanges *rangesIn, const int nb) : ranges(rangesIn), nb_colors(nb) { }
-    bool isStatic() const { return false; }
-    int numPlanes() const { return ranges->numPlanes(); }
+    bool isStatic() const override { return false; }
+    int numPlanes() const override { return ranges->numPlanes(); }
 
-    ColorVal min(int p) const { if (p<3) return 0; else return ranges->min(p); }
-    ColorVal max(int p) const { switch(p) {
+    ColorVal min(int p) const override { if (p<3) return 0; else return ranges->min(p); }
+    ColorVal max(int p) const override { switch(p) {
                                         case 0: return 0;
                                         case 1: return nb_colors-1;
                                         case 2: return 0;
                                         default: return ranges->max(p);
                                          };
                               }
-    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const {
+    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const override {
          if (p==1) { minv=0; maxv=nb_colors-1; return;}
          else if (p<3) { minv=0; maxv=0; return;}
          else ranges->minmax(p,pp,minv,maxv);
@@ -63,11 +63,11 @@ protected:
     bool ordered_palette;
 
 public:
-    void configure(const int setting) {
+    void configure(const int setting) override {
         if (setting>0) { ordered_palette=true; max_palette_size = setting;}
         else {ordered_palette=false; max_palette_size = -setting;}
     }
-    bool init(const ColorRanges *srcRanges) {
+    bool init(const ColorRanges *srcRanges) override {
         if (srcRanges->numPlanes() < 3) return false;
         if (srcRanges->max(0) == 0 && srcRanges->max(2) == 0 &&
             srcRanges->numPlanes() > 3 && srcRanges->min(3) == 1 && srcRanges->max(3) == 1) return false; // already did PLA!
@@ -77,11 +77,11 @@ public:
         return true;
     }
 
-    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) {
+    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) override {
         for (Image& image : images) image.palette=true;
         return new ColorRangesPalette(srcRanges, Palette_vector.size());
     }
-    void invData(Images& images) const {
+    void invData(Images& images) const override {
         for (Image& image : images) {
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1); // only needed when there is only one palette color, so plane 1 is also constant
@@ -99,7 +99,7 @@ public:
     }
 
 #ifdef HAS_ENCODER
-    bool process(const ColorRanges *, const Images &images) {
+    bool process(const ColorRanges *, const Images &images) override {
         if (ordered_palette) {
           std::set<Color> Palette;
           for (const Image& image : images)
@@ -131,7 +131,7 @@ public:
 //        printf("Palette size: %lu\n",Palette.size());
         return true;
     }
-    void data(Images& images) const {
+    void data(Images& images) const override {
 //        printf("TransformPalette::data\n");
         for (Image& image : images) {
           for (uint32_t r=0; r<image.rows(); r++) {
@@ -148,7 +148,7 @@ public:
           image.make_constant_plane(2,0);
         }
     }
-    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coder(rac);
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coderY(rac);
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coderI(rac);
@@ -192,7 +192,7 @@ public:
         if (!ordered_palette) v_printf(5,"Unsorted");
     }
 #endif
-    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coder(rac);
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coderY(rac);
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coderI(rac);

--- a/src/transform/palette_C.hpp
+++ b/src/transform/palette_C.hpp
@@ -31,12 +31,12 @@ protected:
     int nb_colors[4];
 public:
     ColorRangesPaletteC(const ColorRanges *rangesIn, const int nb[4]) : ranges(rangesIn) { for (int i=0; i<4; i++) nb_colors[i] = nb[i]; }
-    bool isStatic() const { return true; }
-    int numPlanes() const { return ranges->numPlanes(); }
+    bool isStatic() const override { return true; }
+    int numPlanes() const override { return ranges->numPlanes(); }
 
-    ColorVal min(int p) const { return 0; }
-    ColorVal max(int p) const { return nb_colors[p]; }
-    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const {
+    ColorVal min(int p) const override { return 0; }
+    ColorVal max(int p) const override { return nb_colors[p]; }
+    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const override {
          minv=0; maxv=nb_colors[p];
     }
 
@@ -50,11 +50,11 @@ protected:
     std::vector<ColorVal> CPalette_inv_vector[4];
 
 public:
-    bool init(const ColorRanges *) {
+    bool init(const ColorRanges *) override {
         return true;
     }
 
-    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) {
+    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) override {
         int nb[4] = {};
         v_printf(4,"[");
         for (int i=0; i<srcRanges->numPlanes(); i++) {
@@ -67,7 +67,7 @@ public:
         return new ColorRangesPaletteC(srcRanges, nb);
     }
 
-    void invData(Images& images) const {
+    void invData(Images& images) const override {
         for (Image& image : images) {
          for (int p=0; p<image.numPlanes(); p++) {
 //          const int stretch = (CPalette_vector[p].size()>64 ? 0 : 2);
@@ -83,7 +83,7 @@ public:
     }
 
 #if HAS_ENCODER
-    bool process(const ColorRanges *srcRanges, const Images &images) {
+    bool process(const ColorRanges *srcRanges, const Images &images) override {
         std::set<ColorVal> CPalette;
         bool nontrivial=false;
         for (int p=0; p<srcRanges->numPlanes(); p++) {
@@ -114,7 +114,7 @@ public:
         }
         return nontrivial;
     }
-    void data(Images& images) const {
+    void data(Images& images) const override {
         for (Image& image : images) {
          for (int p=0; p<image.numPlanes(); p++) {
 //          const int stretch = (CPalette_vector[p].size()>64 ? 0 : 2);
@@ -129,7 +129,7 @@ public:
          }
         }
     }
-    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 18> coder(rac);
         for (int p=0; p<srcRanges->numPlanes(); p++) {
           coder.write_int(0, srcRanges->max(p)-srcRanges->min(p), CPalette_vector[p].size()-1);
@@ -143,7 +143,7 @@ public:
         }
     }
 #endif
-    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+    bool load(const ColorRanges *srcRanges, RacIn<IO> &rac) override {
         SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 18> coder(rac);
         for (int p=0; p<srcRanges->numPlanes(); p++) {
           unsigned int nb = coder.read_int(0, srcRanges->max(p)-srcRanges->min(p)) + 1;

--- a/src/transform/yc1c2.hpp
+++ b/src/transform/yc1c2.hpp
@@ -69,7 +69,7 @@ protected:
     const ColorRanges *ranges;
 
 public:
-    bool virtual init(const ColorRanges *srcRanges) {
+    bool virtual init(const ColorRanges *srcRanges) override {
         if (srcRanges->numPlanes() < 3) return false;
         if (srcRanges->min(0) < 0 || srcRanges->min(1) < 0 || srcRanges->min(2) < 0) return false;
         if (srcRanges->min(0) == srcRanges->max(0) || srcRanges->min(1) == srcRanges->max(1) || srcRanges->min(2) == srcRanges->max(2)) return false;
@@ -78,12 +78,12 @@ public:
         return true;
     }
 
-    const ColorRanges *meta(Images&, const ColorRanges *srcRanges) {
+    const ColorRanges *meta(Images&, const ColorRanges *srcRanges) override {
         return new ColorRangesYCC(maximum, srcRanges);
     }
 
 #ifdef HAS_ENCODER
-    void data(Images& images) const {
+    void data(Images& images) const override {
         ColorVal R,G,B,Y,C1,C2;
         for (Image& image : images)
         for (uint32_t r=0; r<image.rows(); r++) {
@@ -103,7 +103,7 @@ public:
         }
     }
 #endif
-    void invData(Images& images) const {
+    void invData(Images& images) const override {
         ColorVal R,G,B,Y,C1,C2;
         const ColorVal max[3] = {ranges->max(0), ranges->max(1), ranges->max(2)};
         for (Image& image : images) {

--- a/src/transform/ycocg.hpp
+++ b/src/transform/ycocg.hpp
@@ -144,10 +144,10 @@ public:
             : par(parIn), ranges(rangesIn) {
     //        if (parIn != par) printf("OOPS: using YCoCg transform on something other than rgb888 ?\n");
     }
-    bool isStatic() const { return false; }
-    int numPlanes() const { return ranges->numPlanes(); }
+    bool isStatic() const override { return false; }
+    int numPlanes() const override { return ranges->numPlanes(); }
 
-    ColorVal min(int p) const {
+    ColorVal min(int p) const override {
       switch(p) {
         case 0: return 0;
         case 1: return -4*par+1;
@@ -155,7 +155,7 @@ public:
         default: return ranges->min(p);
       };
     }
-    ColorVal max(int p) const {
+    ColorVal max(int p) const override {
       switch(p) {
         case 0: return 4*par-1;
         case 1: return 4*par-1;
@@ -164,7 +164,7 @@ public:
       };
     }
 
-    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const {
+    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const override {
          if (p==1) { minv=get_min_co(par, pp[0]); maxv=get_max_co(par, pp[0]); return; }
          else if (p==2) { minv=get_min_cg(par, pp[0], pp[1]); maxv=get_max_cg(par, pp[0], pp[1]); return; }
          else if (p==0) { minv=0; maxv=get_max_y(par); return;}
@@ -180,7 +180,7 @@ protected:
     const ColorRanges *ranges;
 
 public:
-    bool virtual init(const ColorRanges *srcRanges) {
+    bool virtual init(const ColorRanges *srcRanges) override {
         if (srcRanges->numPlanes() < 3) return false;
         if (srcRanges->min(0) < 0 || srcRanges->min(1) < 0 || srcRanges->min(2) < 0) return false;
         if (srcRanges->min(0) == srcRanges->max(0) || srcRanges->min(1) == srcRanges->max(1) || srcRanges->min(2) == srcRanges->max(2)) return false;
@@ -190,12 +190,12 @@ public:
         return true;
     }
 
-    const ColorRanges *meta(Images&, const ColorRanges *srcRanges) {
+    const ColorRanges *meta(Images&, const ColorRanges *srcRanges) override {
         return new ColorRangesYCoCg(par, srcRanges);
     }
 
 #ifdef HAS_ENCODER
-    void data(Images& images) const {
+    void data(Images& images) const override {
 //        printf("TransformYCoCg::data: par=%i\n", par);
         ColorVal R,G,B,Y,Co,Cg;
         for (Image& image : images)
@@ -221,7 +221,7 @@ public:
         }
     }
 #endif
-    void invData(Images& images) const {
+    void invData(Images& images) const override {
         const ColorVal max[3] = {ranges->max(0), ranges->max(1), ranges->max(2)};
         for (Image& image : images) {
           image.undo_make_constant_plane(0);


### PR DESCRIPTION
Since C++11 (and newer versions) supports override specifier, it should
be used. This makes porting to another languages a bit easier since
override word can be directly spotted from the code.