### PR TITLE
Use __BYTE_ORDER__ macro instead of __BYTE_ORDER

### DIFF
--- a/src/image/crc32k.hpp
+++ b/src/image/crc32k.hpp
@@ -9,9 +9,9 @@
   typedef unsigned __int32 uint32_t;
   typedef   signed __int32  int32_t;
 
-  #define __LITTLE_ENDIAN 1234
-  #define __BIG_ENDIAN    4321
-  #define __BYTE_ORDER    __LITTLE_ENDIAN
+  #define __ORDER_BIG_ENDIAN__ 4321
+  #define __ORDER_LITTLE_ENDIAN__ 1234
+  #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
 
   #include <xmmintrin.h>
   #ifdef __MINGW32__

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -322,7 +322,7 @@ public:
         v.visit(*this);
     }
     uint32_t compute_crc32(uint32_t previous_crc32) override {
-#if __BYTE_ORDER == __BIG_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         // temporarily make the buffer little endian (TODO: avoid this by modifying the crc to take the swapped bytes into account directly)
         if (sizeof(pixel_t) == 2) {
             for (pixel_t& x : data) x = swap16(x);
@@ -331,7 +331,7 @@ public:
         }
 #endif
         uint32_t result = crc32_fast(&data_vec[0], width*height*sizeof(pixel_t), previous_crc32);
-#if __BYTE_ORDER == __BIG_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         // make the buffer big endian again
         if (sizeof(pixel_t) == 2) {
             for (pixel_t& x : data) x = swap16(x);


### PR DESCRIPTION
```
Both clang and gcc define __BYTE_ORDER__ on Linux and OS X. This fixes
the build on OS X which doesn't have __BYTE_ORDER defined.
```