### PR TITLE
raw-tools/sony_arw: add support for padding different than 0x00

### DIFF
--- a/raw-tools/sony_arw/arw_compress.sh
+++ b/raw-tools/sony_arw/arw_compress.sh
@@ -24,11 +24,26 @@ fi
 
 DIR=$(mktemp -d "$DST.XXXXXX")
 
+cat <<EOL > "$DIR"/file.list
+$DIR/alarms.bin
+$DIR/begin
+$DIR/orig.sha256
+EOL
+
 sha256sum - < "$SRC" > "$DIR"/orig.sha256
 dcraw_hack "$SRC" > "$DIR"/temp.rgba 2> "$DIR"/err
 HALF_SIZE=$(head -n1 "$DIR"/err | sed -e 's/^.*, half=\([0-9]*x[0-9]*\)$/\1/')
 convert -depth 16 -size $HALF_SIZE rgba:"$DIR"/temp.rgba png:"$DIR"/temp.png
 grep ALARM "$DIR"/err | cut -c 8- | xxd -r -ps > "$DIR"/alarms.bin
+LAST_LINE=$(tail -n1 "$DIR"/err)
+PADDING_BYTE=00
+if (echo "$LAST_LINE" | grep -q PADDING "$DIR"/err)
+then
+	PADDING_BYTE=$(echo "$LAST_LINE" | cut -c 10-)
+	echo $PADDING_BYTE | xxd -r -ps > "$DIR"/padding
+	echo "$DIR"/padding >> "$DIR"/file.list
+fi
+
 START=$(head -n1 "$DIR"/err | sed -e 's/^.*data_at=//' -e 's/, .*$//')
 HALF_WIDTH=$(echo $HALF_SIZE | sed -e 's/x.*$//')
 
@@ -37,11 +52,11 @@ flif -e --keep-invisible-rgb "$DIR"/temp.png "$DIR"/result.flif
 flif -d "$DIR"/result.flif "$DIR"/result.flif.png
 head -c $START "$SRC" > "$DIR"/begin
 
-if (cat "$DIR"/begin; convert "$DIR"/result.flif.png -depth 16 rgba:- | arw_encode $HALF_WIDTH $START "$DIR"/alarms.bin) | cmp - "$SRC"
+if (cat "$DIR"/begin; convert "$DIR"/result.flif.png -depth 16 rgba:- | arw_encode $HALF_WIDTH $START "$DIR"/alarms.bin $PADDING_BYTE) | cmp - "$SRC"
 then
-	tar --transform 's=^.*/==' -Jcf "$DIR"/{extra.tar.xz,alarms.bin,begin,orig.sha256}
+	cat "$DIR"/file.list | xargs tar --transform 's=^.*/==' -Jcf "$DIR"/extra.tar.xz
 	tar --transform 's=^.*/==' -cf "$DST" "$DIR"/extra.tar.xz "$DIR"/result.flif
-	rm "$DIR"/{extra.tar.xz,result.flif,alarms.bin,begin,err,result.flif.png,temp.png,orig.sha256,temp.rgba}
+	cat "$DIR"/file.list | xargs rm "$DIR"/{extra.tar.xz,result.flif,err,result.flif.png,temp.png,temp.rgba,file.list}
 	rmdir "$DIR"
 else
 	echo data mismatch, temp stuff left in $DIR

--- a/raw-tools/sony_arw/arw_decompress.sh
+++ b/raw-tools/sony_arw/arw_decompress.sh
@@ -28,9 +28,15 @@ tar -C "$DIR" -xf "$SRC"
 tar -C "$DIR" -Jxf "$DIR"/extra.tar.xz
 START=$(stat -c '%s' "$DIR"/begin)
 HALF_WIDTH=$(flif -i "$DIR"/result.flif | sed -e 's/^.*FLIF image, \([0-9]*\)x.*$/\1/')
+PADDING=00
+if [ -e "$DIR"/padding ]
+then
+	PADDING=$(head -c1 "$DIR/padding" | xxd -ps)
+	rm "$DIR"/padding
+fi
 
 flif -d "$DIR"/result.flif "$DIR"/result.flif.png
-(cat "$DIR"/begin; convert "$DIR"/result.flif.png -depth 16 rgba:- | arw_encode $HALF_WIDTH $START "$DIR"/alarms.bin) > "$DST"
+(cat "$DIR"/begin; convert "$DIR"/result.flif.png -depth 16 rgba:- | arw_encode $HALF_WIDTH $START "$DIR"/alarms.bin $PADDING) > "$DST"
 if ! sha256sum --quiet -c "$DIR"/orig.sha256 < "$DST"
 then
 	echo "SHA mismatch, $DST broken, stuff left in $DIR :-("

--- a/raw-tools/sony_arw/dcraw.c
+++ b/raw-tools/sony_arw/dcraw.c
@@ -2796,6 +2796,14 @@ void CLASS sony_arw2_load_raw()
 	  chunk_cnt++;
     }
   }
+
+  // 2 of tested cameras added zeroes for padding, whereas 1 added 0xFF
+  // instead
+  data[0] = 0;
+  fread(data, 1, 1, ifp);
+  if(data[0] != 0)
+	  fprintf(stderr, "PADDING: %hhx\n", data[0]);
+
   free (data);
   free(debayer_buf);
 }


### PR DESCRIPTION
some cameras seem to prefer 0xFF instead.

@jonsneyers while I'm happy to copy all the changes to arw_compressor in separate pull requests to FLIF, maybe there's some better way to manage this... I'm thinking maybe a git submodule could work here? Not sure how well that works with Github, haven't tried that yet.