### PR TITLE
Removed cinttypes include and added missing typedef.

### DIFF
--- a/src/image/crc32k.hpp
+++ b/src/image/crc32k.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <stdlib.h>
-#include <cinttypes>
 
 // define endianess and some integer data types
 #if defined(_MSC_VER) || defined(__MINGW32__)
   typedef unsigned __int8  uint8_t;
+  typedef unsigned __int16 uint16_t;
   typedef unsigned __int32 uint32_t;
   typedef   signed __int32  int32_t;
 


### PR DESCRIPTION
This patch removes the cinttypes include that won't work for older versions of Visual Studio. It also adds a missing typedef to fix the build.