### PR TITLE
Make alignment optional (conditioned on USE_SIMD)

### DIFF
--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -223,12 +223,18 @@ template <typename pixel_t> class Plane final : public GeneralPlane {
 
 public:
     Plane(uint32_t w, uint32_t h, ColorVal color=0, int scale = 0) : data_vec(PAD(SCALED(w)*SCALED(h)), color), width(SCALED(w)), height(SCALED(h)), s(scale) {
+      // Align only when required. The emscripten port doesn't work with padded alignment and doesn't support SIMD, so
+      // `USE_SIMD` is a good condition for alignment, for now.
+#ifdef USE_SIMD
         //size_t space = data_vec.size()*sizeof(pixel_t);
         void *ptr = data_vec.data();
         //std::align (C++11) is not in GCC or Clang (the versions used by Travis-CI at least) for some stupid reason
         //data = static_cast<pixel_t*>(std::align(16,16,ptr,space));
         uintptr_t diff = (uintptr_t)ptr % 16;
         data = static_cast<pixel_t*>((diff == 0) ? ptr : ((char*)ptr) + (16-diff));
+#else
+        data = data_vec.data();
+#endif
         assert(data != nullptr);
     }
     void clear() {


### PR DESCRIPTION
This is to maintain parity with poly-flif, which doesn't work with aligned pointers