### PR TITLE
Fixed extension for OS X

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,17 +42,17 @@ dflif: $(FILES_H) $(FILES_CPP) flif.cpp
 # Decoder-only library - Apache2 (not built by default)
 libflif_dec$(LIBEXT): $(FILES_H) $(FILES_CPP) library/flif_dec.h library/flif-interface-private_dec.hpp library/flif-interface_dec.cpp
 	echo $(OS)
-	$(CXX) -std=gnu++11 $(CXXFLAGS) $(LIB_OPTIMIZATIONS) -DDECODER_ONLY -g0 -Wall -shared -fPIC $(FILES_CPP) library/flif-interface_dec.cpp $(LDFLAGS) -Wl,$(SONAME),libflif_dec$(LIBEXT).0 -o libflif_dec$(LIBEXT).0
-	ln -sf libflif_dec$(LIBEXT).0 libflif_dec$(LIBEXT)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) $(LIB_OPTIMIZATIONS) -DDECODER_ONLY -g0 -Wall -shared -fPIC $(FILES_CPP) library/flif-interface_dec.cpp $(LDFLAGS) -Wl,$(SONAME),libflif_dec.0$(LIBEXT) -o libflif_dec.0$(LIBEXT)
+	ln -sf libflif_dec.0$(LIBEXT) libflif_dec$(LIBEXT)
 
 # Decoder + encoder library - LGPL
 libflif$(LIBEXT): $(FILES_H) $(FILES_CPP) library/*.h library/*.hpp library/*.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) $(LIB_OPTIMIZATIONS) -g0 -Wall -shared -fPIC $(FILES_CPP) library/flif-interface.cpp $(LDFLAGS) -Wl,$(SONAME),libflif$(LIBEXT).0 -o libflif$(LIBEXT).0
-	ln -sf libflif$(LIBEXT).0 libflif$(LIBEXT)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) $(LIB_OPTIMIZATIONS) -g0 -Wall -shared -fPIC $(FILES_CPP) library/flif-interface.cpp $(LDFLAGS) -Wl,$(SONAME),libflif.0$(LIBEXT) -o libflif.0$(LIBEXT)
+	ln -sf libflif.0$(LIBEXT) libflif$(LIBEXT)
 
 libflif.dbg$(LIBEXT): $(FILES_H) $(FILES_CPP) library/*.h library/*.hpp library/*.cpp
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -O1 -ggdb3 -Wall -shared -fPIC $(FILES_CPP) library/flif-interface.cpp $(LDFLAGS) -Wl,$(SONAME),libflif$(LIBEXT).0 -o libflif.dbg$(LIBEXT).0
-	ln -sf libflif.dbg$(LIBEXT).0 libflif.dbg$(LIBEXT)
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -O1 -ggdb3 -Wall -shared -fPIC $(FILES_CPP) library/flif-interface.cpp $(LDFLAGS) -Wl,$(SONAME),libflif.0$(LIBEXT) -o libflif.dbg.0$(LIBEXT)
+	ln -sf libflif.dbg.0$(LIBEXT) libflif.dbg$(LIBEXT)
 
 # Example application: simple FLIF viewer - public domain
 viewflif: libflif$(LIBEXT) viewflif.c
@@ -85,8 +85,8 @@ uninstall:
 	rm -f $(PREFIX)/bin/apng2flif
 	rm -f $(PREFIX)/lib/libflif$(LIBEXT)
 	rm -f $(PREFIX)/lib/libflif_dec$(LIBEXT)
-	rm -f $(PREFIX)/lib/libflif$(LIBEXT).0
-	rm -f $(PREFIX)/lib/libflif_dec$(LIBEXT).0
+	rm -f $(PREFIX)/lib/libflif.0$(LIBEXT)
+	rm -f $(PREFIX)/lib/libflif_dec.0$(LIBEXT)
 	rm -f $(PREFIX)/share/man/man1/flif.1
 
 clean:


### PR DESCRIPTION
I put the version number before the extension, because the other way is
just dumb.

I've been sitting on this patch for a long ass time and it's just time I push it upstream.