### PR TITLE
Functions for import of Images with RGBA, RGB or Grayscale

### DIFF
--- a/src/library/flif-interface-private_common.hpp
+++ b/src/library/flif-interface-private_common.hpp
@@ -43,5 +43,7 @@ struct FLIF_IMAGE
     void write_row_RGBA16(uint32_t row, const void* buffer, size_t buffer_size_bytes);
     void read_row_RGBA16(uint32_t row, void* buffer, size_t buffer_size_bytes);
 
+    void write_row_RGB8(uint32_t row, const void* buffer, size_t buffer_size_bytes);
+    void write_row_GRAY8(uint32_t row, const void* buffer, size_t buffer_size_bytes);
     Image image;
 };

--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -22,6 +22,9 @@ limitations under the License.
 FLIF_IMAGE::FLIF_IMAGE() { }
 
 #pragma pack(push,1)
+struct FLIF_RGB {
+	uint8_t r, g, b;
+};
 struct FLIF_RGBA {
     uint8_t r,g,b,a;
 };
@@ -48,6 +51,52 @@ void FLIF_IMAGE::write_row_RGBA8(uint32_t row, const void* buffer, size_t buffer
             image.set(3, row, c, buffer_rgba[c].a);
         }
     }
+}
+
+void FLIF_IMAGE::write_row_RGB8(uint32_t row, const void * buffer, size_t buffer_size_bytes)
+{
+	if (buffer_size_bytes < image.cols() * sizeof(FLIF_RGB))
+		return;
+
+	const FLIF_RGB* buffer_rgb = reinterpret_cast<const FLIF_RGB*>(buffer);
+
+	if (image.numPlanes() >= 3) {
+		for (size_t c = 0; c < (size_t)image.cols(); c++) {
+			image.set(0, row, c, buffer_rgb[c].r);
+			image.set(1, row, c, buffer_rgb[c].g);
+			image.set(2, row, c, buffer_rgb[c].b);
+		}
+	}
+	if (image.numPlanes() >= 4) {
+		for (size_t c = 0; c < (size_t)image.cols(); c++) {
+			image.set(3, row, c, 0xFF); // fully opaque
+		}
+	}
+}
+
+void FLIF_IMAGE::write_row_GRAY8(uint32_t row, const void * buffer, size_t buffer_size_bytes)
+{
+	if (buffer_size_bytes < image.cols() * sizeof(uint8_t))
+		return;
+
+	const uint8_t* buffer_gray = reinterpret_cast<const uint8_t*>(buffer);
+
+	if (image.numPlanes() >= 1) {
+		for (size_t c = 0; c < (size_t)image.cols(); c++) {
+			image.set(0, row, c, buffer_gray[c]);
+		}
+	}
+	if (image.numPlanes() >= 3) {
+		for (size_t c = 0; c < (size_t)image.cols(); c++) {
+			image.set(1, row, c, buffer_gray[c]);
+			image.set(2, row, c, buffer_gray[c]);
+		}
+	}
+	if (image.numPlanes() >= 4) {
+		for (size_t c = 0; c < (size_t)image.cols(); c++) {
+			image.set(3, row, c, 0xFF); // fully opaque
+		}
+	}
 }
 
 void FLIF_IMAGE::read_row_RGBA8(uint32_t row, void* buffer, size_t buffer_size_bytes) {
@@ -186,6 +235,63 @@ FLIF_DLLEXPORT FLIF_IMAGE* FLIF_API flif_create_image_HDR(uint32_t width, uint32
     catch(...) {}
     return 0;
 }
+
+	FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_import_image_RGBA(uint32_t width, uint32_t height, const void* rgba, uint32_t rgba_stride) {
+		try
+		{
+			const int number_components = 4;
+			if (width == 0 || height == 0 || rgba_stride < width*number_components)
+				return 0;
+			std::unique_ptr<FLIF_IMAGE> image(new FLIF_IMAGE());
+			image->image.init(width, height, 0, 255, number_components);
+			const uint8_t* buffer = static_cast<const uint8_t*>(rgba);
+			for (uint32_t row = 0; row < height; ++row) {
+				image->write_row_RGBA8(row, buffer, width*number_components);
+				buffer += rgba_stride;
+			}
+			return image.release();
+		}
+		catch (...) {}
+		return 0;
+	}
+
+	FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_import_image_RGB(uint32_t width, uint32_t height, const void* rgb, uint32_t rgb_stride) {
+		try
+		{
+			const int number_components = 3;
+			if (width == 0 || height == 0 || rgb_stride < width*number_components)
+				return 0;
+			std::unique_ptr<FLIF_IMAGE> image(new FLIF_IMAGE());
+			image->image.init(width, height, 0, 255, number_components);
+			const uint8_t* buffer = static_cast<const uint8_t*>(rgb);
+			for (uint32_t row = 0; row < height; ++row) {
+				image->write_row_RGB8(row, buffer, width*number_components);
+				buffer += rgb_stride;
+			}
+			return image.release();
+		}
+		catch (...) {}
+		return 0;
+	}
+
+	FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_import_image_GRAY(uint32_t width, uint32_t height, const void* gray, uint32_t gray_stride) {
+		try
+		{
+			const int number_components = 1;
+			if (width == 0 || height == 0 || gray_stride < width*number_components)
+				return 0;
+			std::unique_ptr<FLIF_IMAGE> image(new FLIF_IMAGE());
+			image->image.init(width, height, 0, 255, number_components);
+			const uint8_t* buffer = static_cast<const uint8_t*>(gray);
+			for (uint32_t row = 0; row < height; ++row) {
+				image->write_row_GRAY8(row, buffer, width*number_components);
+				buffer += gray_stride;
+			}
+			return image.release();
+		}
+		catch (...) {}
+		return 0;
+	}
 
 FLIF_DLLEXPORT void FLIF_API flif_destroy_image(FLIF_IMAGE* image) {
     // delete should never let exceptions out

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -45,6 +45,9 @@ extern "C" {
 
     FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_create_image(uint32_t width, uint32_t height);
     FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_create_image_HDR(uint32_t width, uint32_t height);
+    FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_import_image_RGBA(uint32_t width, uint32_t height, const void* rgba, uint32_t rgba_stride);
+    FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_import_image_RGB(uint32_t width, uint32_t height, const void* rgb, uint32_t rgb_stride);
+    FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_import_image_GRAY(uint32_t width, uint32_t height, const void* gray, uint32_t gray_stride);
     FLIF_DLLIMPORT void FLIF_API flif_destroy_image(FLIF_IMAGE* image);
 
     FLIF_DLLIMPORT uint32_t FLIF_API flif_image_get_width(FLIF_IMAGE* image);


### PR DESCRIPTION
New functions in flif_common.h:
* flif_import_image_RGBA
* flif_import_image_RGB
* flif_import_image_GRAY

New private functions
* write_row_RGB8
* write_row_GRAY8

Naming of functions is *import* and not *create*, because that's the naming convention the webp codec also uses.