### PR TITLE
Basic library wrappers for Image::get_metadata and Image::set_metadata 

### DIFF
--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -901,6 +901,15 @@ public:
         }
         return false;  // metadata not found
     }
+    void free_metadata(unsigned char * data) const {
+        if(data) {
+#ifdef LODEPNG_COMPILE_ALLOCATORS
+            free(data);
+#else
+            lodepng_free(data);
+#endif // !LODEPNG_COMPILE_ALLOCATORS            
+        }
+    }
     void set_metadata(const char * chunkname, const unsigned char * data, size_t length) {
         MetaData foo;
         strcpy(foo.name, chunkname);

--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -353,6 +353,14 @@ FLIF_DLLEXPORT void FLIF_API flif_image_set_frame_delay(FLIF_IMAGE* image, uint3
     catch(...) {}
 }
 
+FLIF_DLLEXPORT void FLIF_API flif_image_set_metadata(FLIF_IMAGE* image, const char* chunkname, const unsigned char* data, size_t length) {
+    try
+    {
+        image->image.set_metadata(chunkname, data, length);
+    }
+    catch(...) {}
+}
+
 FLIF_DLLEXPORT void FLIF_API flif_image_write_row_RGBA8(FLIF_IMAGE* image, uint32_t row, const void* buffer, size_t buffer_size_bytes) {
     try
     {

--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -361,6 +361,14 @@ FLIF_DLLEXPORT void FLIF_API flif_image_set_metadata(FLIF_IMAGE* image, const ch
     catch(...) {}
 }
 
+FLIF_DLLIMPORT void FLIF_API flif_image_get_metadata(FLIF_IMAGE* image, const char* chunkname, unsigned char** data, size_t* length){
+    try
+    {
+        image->image.get_metadata(chunkname, data, length);
+    }
+    catch(...) {}
+}
+
 FLIF_DLLEXPORT void FLIF_API flif_image_write_row_RGBA8(FLIF_IMAGE* image, uint32_t row, const void* buffer, size_t buffer_size_bytes) {
     try
     {

--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -369,6 +369,14 @@ FLIF_DLLIMPORT void FLIF_API flif_image_get_metadata(FLIF_IMAGE* image, const ch
     catch(...) {}
 }
 
+FLIF_DLLIMPORT void FLIF_API flif_image_free_metadata(FLIF_IMAGE* image, unsigned char* data){
+    try
+    {
+        image->image.free_metadata(data);
+    }
+    catch(...) {}
+}
+
 FLIF_DLLEXPORT void FLIF_API flif_image_write_row_RGBA8(FLIF_IMAGE* image, uint32_t row, const void* buffer, size_t buffer_size_bytes) {
     try
     {

--- a/src/library/flif-interface_dec.cpp
+++ b/src/library/flif-interface_dec.cpp
@@ -98,7 +98,7 @@ FLIF_IMAGE* FLIF_DECODER::get_image(size_t index) {
         return 0;
     if(index >= requested_images.size()) requested_images.resize(images.size());
     if (!requested_images[index].get()) requested_images[index].reset( new FLIF_IMAGE());
-    if (images[index].rows()) {
+    if (images[index].rows() || images[index].metadata.size() > 0) {
         requested_images[index]->image = std::move(images[index]); // moves and invalidates images[index]
     }
     return requested_images[index].get();

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -24,11 +24,11 @@ limitations under the License.
 
 #ifdef _MSC_VER
 #define FLIF_API __cdecl
- #ifdef FLIF_BUILD_DLL
-  #define FLIF_DLLIMPORT __declspec(dllexport)
- #elif FLIF_USE_DLL
-  #define FLIF_DLLIMPORT __declspec(dllimport)
- #endif
+#ifdef FLIF_BUILD_DLL
+#define FLIF_DLLIMPORT __declspec(dllexport)
+#elif FLIF_USE_DLL
+#define FLIF_DLLIMPORT __declspec(dllimport)
+#endif
 #else
 #define FLIF_API
 #endif
@@ -56,6 +56,7 @@ extern "C" {
     FLIF_DLLIMPORT uint8_t  FLIF_API flif_image_get_depth(FLIF_IMAGE* image);
     FLIF_DLLIMPORT uint32_t FLIF_API flif_image_get_frame_delay(FLIF_IMAGE* image);
     FLIF_DLLIMPORT void FLIF_API flif_image_set_frame_delay(FLIF_IMAGE* image, uint32_t delay);
+    FLIF_DLLIMPORT void FLIF_API flif_image_set_metadata(FLIF_IMAGE* image, const char* chunkname, const unsigned char* data, size_t length);
 
     FLIF_DLLIMPORT void FLIF_API flif_image_write_row_RGBA8(FLIF_IMAGE* image, uint32_t row, const void* buffer, size_t buffer_size_bytes);
     FLIF_DLLIMPORT void FLIF_API flif_image_read_row_RGBA8(FLIF_IMAGE* image, uint32_t row, void* buffer, size_t buffer_size_bytes);

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -59,6 +59,7 @@ extern "C" {
 
     FLIF_DLLIMPORT void FLIF_API flif_image_set_metadata(FLIF_IMAGE* image, const char* chunkname, const unsigned char* data, size_t length);
     FLIF_DLLIMPORT void FLIF_API flif_image_get_metadata(FLIF_IMAGE* image, const char* chunkname, unsigned char** data, size_t* length);
+    FLIF_DLLIMPORT void FLIF_API flif_image_free_metadata(FLIF_IMAGE* image, unsigned char* data);
 
     FLIF_DLLIMPORT void FLIF_API flif_image_write_row_RGBA8(FLIF_IMAGE* image, uint32_t row, const void* buffer, size_t buffer_size_bytes);
     FLIF_DLLIMPORT void FLIF_API flif_image_read_row_RGBA8(FLIF_IMAGE* image, uint32_t row, void* buffer, size_t buffer_size_bytes);

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -24,11 +24,11 @@ limitations under the License.
 
 #ifdef _MSC_VER
 #define FLIF_API __cdecl
-#ifdef FLIF_BUILD_DLL
-#define FLIF_DLLIMPORT __declspec(dllexport)
-#elif FLIF_USE_DLL
-#define FLIF_DLLIMPORT __declspec(dllimport)
-#endif
+ #ifdef FLIF_BUILD_DLL
+  #define FLIF_DLLIMPORT __declspec(dllexport)
+ #elif FLIF_USE_DLL
+  #define FLIF_DLLIMPORT __declspec(dllimport)
+  #endif
 #else
 #define FLIF_API
 #endif

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -28,7 +28,7 @@ limitations under the License.
   #define FLIF_DLLIMPORT __declspec(dllexport)
  #elif FLIF_USE_DLL
   #define FLIF_DLLIMPORT __declspec(dllimport)
-  #endif
+ #endif
 #else
 #define FLIF_API
 #endif
@@ -56,7 +56,9 @@ extern "C" {
     FLIF_DLLIMPORT uint8_t  FLIF_API flif_image_get_depth(FLIF_IMAGE* image);
     FLIF_DLLIMPORT uint32_t FLIF_API flif_image_get_frame_delay(FLIF_IMAGE* image);
     FLIF_DLLIMPORT void FLIF_API flif_image_set_frame_delay(FLIF_IMAGE* image, uint32_t delay);
+
     FLIF_DLLIMPORT void FLIF_API flif_image_set_metadata(FLIF_IMAGE* image, const char* chunkname, const unsigned char* data, size_t length);
+    FLIF_DLLIMPORT void FLIF_API flif_image_get_metadata(FLIF_IMAGE* image, const char* chunkname, unsigned char** data, size_t* length);
 
     FLIF_DLLIMPORT void FLIF_API flif_image_write_row_RGBA8(FLIF_IMAGE* image, uint32_t row, const void* buffer, size_t buffer_size_bytes);
     FLIF_DLLIMPORT void FLIF_API flif_image_read_row_RGBA8(FLIF_IMAGE* image, uint32_t row, void* buffer, size_t buffer_size_bytes);


### PR DESCRIPTION
* metadata get by flif_image_get_metadata has to be freed by flif_image_free_metadata
* change in FLIF_DECODER::get_image, to return image if metadata is set. (For example if scale = -2)