### PR TITLE
Increase lossiness of chroma based on luminance

### DIFF
--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -430,7 +430,8 @@ inline int luma_alpha_compensate(int p, ColorVal Y, ColorVal X, ColorVal A) {
     if (p==0) return 128 + A/2;
 
     // for chroma, take Y into account as well (higher Y => lower loss)
-    return A/2 + Y/2;
+    const int divFactor = A/2 + Y/2;
+    return divFactor == 0 ? 1 : divFactor;
 }
 
 void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int loss, bool adaptive, Image &map) {

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -425,7 +425,12 @@ void flif_make_lossy_scanlines(Images &images, const ColorRanges *ranges, int lo
 }
 inline int luma_alpha_compensate(int p, ColorVal Y, ColorVal X, ColorVal A) {
     if (p==4) return 255;
-    return 128+A/2; // divide by 128 at low alpha (so double loss), 255 at high alpha (normal loss)
+
+    // divide by 128 at low alpha (so double loss), 255 at high alpha (normal loss)
+    if (p==0) return 128 + A/2;
+
+    // opposite logic for Y (higher Y => lower loss)
+    return 128 + A/2 - Y/2;
 }
 void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int loss, bool adaptive, Image &map) {
     ColorVal min,max;

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -429,9 +429,10 @@ inline int luma_alpha_compensate(int p, ColorVal Y, ColorVal X, ColorVal A) {
     // divide by 128 at low alpha (so double loss), 255 at high alpha (normal loss)
     if (p==0) return 128 + A/2;
 
-    // opposite logic for Y (higher Y => lower loss)
-    return 128 + A/2 - Y/2;
+    // for chroma, take Y into account as well (higher Y => lower loss)
+    return A/2 + Y/2;
 }
+
 void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int loss, bool adaptive, Image &map) {
     ColorVal min,max;
     int nump = images[0].numPlanes();

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -423,15 +423,20 @@ void flif_make_lossy_scanlines(Images &images, const ColorRanges *ranges, int lo
         }
     }
 }
-inline int luma_alpha_compensate(int p, ColorVal Y, ColorVal X, ColorVal A) {
+
+inline int luma_alpha_compensate(int p, int z, int numP, ColorVal Y, ColorVal X, ColorVal A) {
     if (p==4) return 255;
 
     // divide by 128 at low alpha (so double loss), 255 at high alpha (normal loss)
-    if (p==0) return 128 + A/2;
+    if (p==0 || p==3) return 128 + A/2;
 
     // for chroma, take Y into account as well (higher Y => lower loss)
-    const int divFactor = A/2 + Y/2;
-    return divFactor == 0 ? 1 : divFactor;
+    if (numP > 3) {
+      const int divFactor = A/2 + (z <= 1 ? Y/2 : 64 + Y/4);
+      return divFactor < 15 ? 15 : divFactor;
+    } else {
+      return 64 + (z <= 1 ? (3*Y)/4 : 96 + Y/2);
+    }
 }
 
 void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int loss, bool adaptive, Image &map) {
@@ -468,7 +473,7 @@ void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int 
                     ColorVal curr = image(p,z,r,c);
                     int factor=255;
                     if (z==0) factor += loss*2;
-                    int actual_loss = (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255));
+                    int actual_loss = (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,z,nump,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255));
                     // example: assume actual_loss > 30, then:
                     //  top:    100                                                     90    (error:0 -> 10)
                     //  curr:   120  -->  150 (guess)    so we compensate and make it   140   (error:30 -> 20)
@@ -518,7 +523,7 @@ void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int 
                     ColorVal curr = image(p,z,r,c);
                     int factor=255;
                     if (z==1) factor += loss;
-                    int actual_loss = (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255));
+                    int actual_loss = (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,z,nump,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255));
                     ColorVal diff = curr-guess;
 //                    if (abs(diff) > actual_loss) continue;
                     if (abs(diff) > actual_loss) continue;
@@ -580,7 +585,7 @@ void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int 
                     factor = ((beginZL-z)*factor/(beginZL));
                     if (z==0) factor += loss*2;
                     ColorVal diff = flif_make_lossy(min - guess, max - guess, curr - guess,
-                                        (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255)));
+                                        (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,z,nump,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255)));
                     ColorVal lossyval = guess+diff;
                     ranges->snap(p,properties,min,max,lossyval);
                     image.set(p,z,r,c, lossyval);
@@ -619,7 +624,7 @@ void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int 
                     factor = ((beginZL-z)*factor/(beginZL));
                     if (z==1) factor += loss;
                     ColorVal diff = flif_make_lossy(min - guess, max - guess, curr - guess,
-                                        (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255)));
+                                        (adaptive? factor-map(0,z,r,c) : factor) * lossp[p] / luma_alpha_compensate(p,z,nump,image(0,z,r,c),image(p,z,r,c),(nump>3?image(3,z,r,c):255)));
                     ColorVal lossyval = guess+diff;
                     ranges->snap(p,properties,min,max,lossyval);
                     image.set(p,z,r,c, lossyval);


### PR DESCRIPTION
Chroma differences are more perceptible in brighter pixels. Hence increasing lossiness
of chroma planes when the luminance is lower yields better compression (with imperceptible loss
in quality).

My quick tests show 12% to 20% reduction in file size for `-Q40` and `-Q20` respectively. Needs testing on a larger corpus.