### PR TITLE
fix -Wmisleading-indentation in flif.cpp reported by gcc 7.0.

### DIFF
--- a/src/flif.cpp
+++ b/src/flif.cpp
@@ -437,7 +437,8 @@ int handle_decode(int argc, char **argv, Images &images, flif_options &options) 
               }
               if (!image.save(filename)) return 2;
             } else {
-              if (!image.save(argv[1])) return 2; counter++;
+              if (!image.save(argv[1])) return 2;
+              counter++;
             }
             v_printf(2,"    (%i/%i)         \r",counter,(int)images.size()); v_printf(4,"\n");
         }


### PR DESCRIPTION
The case was not that critical because if the if was taken we would hit a return so the following code would never execute, anyway the message is fixed now.

Was:
````
flif.cpp: In function ‘int handle_decode(int, char**, Images&, flif_options&)’:
flif.cpp:440:15: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
               if (!image.save(argv[1])) return 2; counter++;
               ^~
flif.cpp:440:51: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
               if (!image.save(argv[1])) return 2; counter++;
                                                   ^~~~~~~
````