### PR TITLE
Change test.c printf format string to fix MSVC build failure.

### DIFF
--- a/tools/test.c
+++ b/tools/test.c
@@ -279,7 +279,7 @@ int main(int argc, char** argv)
                depth != 8 ||
                n != 1)
             {
-                printf("Error: info should be %lux%lu, %d channels, %d bit, %d images.\n"
+                printf("Error: info should be %zux%zu, %d channels, %d bit, %d images.\n"
                        "       Instead it is %dx%d, %d channels, %d bit, %d images.\n",
                        WIDTH, HEIGHT, 4, 8, 1,
                        w, h, channels, depth, n);


### PR DESCRIPTION
Build fails on windows with the following message. This fixes that.
```
..\..\tools\test.c(282): error C2220: warning treated as error - no 'object' file generated
..\..\tools\test.c(282): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'const std::size_t'
..\..\tools\test.c(282): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
..\..\tools\test.c(282): note: consider using '%zu' in the format string
..\..\tools\test.c(282): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 2 has type 'const std::size_t'
..\..\tools\test.c(282): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
..\..\tools\test.c(282): note: consider using '%zu' in the format string
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\cl.EXE"' : return code '0x2'
Stop.
```
This uses C++11 feature, I think it's maybe fine. But I've not tested it on other environments.