### PR TITLE
/usr/local by default

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-PREFIX := $(DESTDIR)/usr
+PREFIX := $(DESTDIR)/usr/local
 CXXFLAGS := $(shell pkg-config --cflags zlib libpng) -DLODEPNG_NO_COMPILE_PNG -DLODEPNG_NO_COMPILE_DISK
 LDFLAGS := $(shell pkg-config --libs libpng)
 


### PR DESCRIPTION
Installing a 3rd party package directly into `/usr` is Very Odd Behavior™. Really, this should be taken care of by a configure script or CMake.