### PR TITLE
Fix out-of-bounds heap access during metadata encoding from PNG

### DIFF
--- a/src/image/image-png-metadata.hpp
+++ b/src/image/image-png-metadata.hpp
@@ -39,7 +39,6 @@ static unsigned char* HexStringToBytes(const char* hexstring,
   return raw_data;
 }
 
-// rewrite
 static int ProcessRawProfile(const char* profile, size_t profile_len,
                              unsigned char ** payload, size_t* payload_len) {
   const char* src = profile;

--- a/src/image/image-png-metadata.hpp
+++ b/src/image/image-png-metadata.hpp
@@ -39,8 +39,9 @@ static unsigned char* HexStringToBytes(const char* hexstring,
   return raw_data;
 }
 
+// rewrite
 static int ProcessRawProfile(const char* profile, size_t profile_len,
-                             unsigned char ** payload) {
+                             unsigned char ** payload, size_t* payload_len) {
   const char* src = profile;
   char* end;
   int expected_length;
@@ -67,6 +68,7 @@ static int ProcessRawProfile(const char* profile, size_t profile_len,
 
   // 'end' now points to the profile payload.
   *payload = HexStringToBytes(end, expected_length);
+  *payload_len = expected_length;
   if (*payload == NULL) return 0;
   return 1;
 }

--- a/src/image/image-png.cpp
+++ b/src/image/image-png.cpp
@@ -302,8 +302,9 @@ int image_load_png(const char *filename, Image &image, metadata_options &options
         }
         if (rawprofile) {
           unsigned char * buffer = NULL;
-          if (ProcessRawProfile(txt->text, length, &buffer)) {
-            image.set_metadata(chunkname, buffer, length);
+          size_t buffer_len = 0;
+          if (ProcessRawProfile(txt->text, length, &buffer, &buffer_len)) {
+            image.set_metadata(chunkname, buffer, buffer_len);
             free(buffer);
           }
         } else {


### PR DESCRIPTION
Scenario:
- convert JPG to PNG with image magick (to preserve any metadata in the JPG)
- convert PNG to FLIF
- extract metadata from FLIF using the API
- **metadata size does not match size in JPG**

This happens because flif is storing the wrong length for the metadata chunk, namely the length it has in PNG, where the chunk is hex-encoded as text. So flif metadata gets encoded with kbytes of garbage at the end of the chunk.