### PR TITLE
travis: fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ compiler:
 sudo: true
 dist: trusty
 
+env:
+  - BUILDTYPE=GNUMAKE
+
+
 before_install:
   - sudo apt-get install build-essential imagemagick libsdl2-dev libimage-exiftool-perl
   # workaround clang not system wide, fail on sudo make install for adms


### PR DESCRIPTION
Apparently, tests don't run without a BUILDTYPE specified!

Looks like I had optimised the tests a bit too much in a previous PR. Fortunately, the tests are still passing and still faster than the earlier configuration :sweat_smile: 