### PR TITLE
Lazy progressive

### DIFF
--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -220,7 +220,9 @@ uint32_t issue_callback(callback_t callback, void *user_data, uint32_t quality, 
   cb_info->quality = quality;
   cb_info->bytes_read = bytes_read;
   cb_info->populateContext = (void *) &func;
-  return callback(cb_info, user_data);
+  uint32_t retValue = callback(cb_info, user_data);
+  free(cb_info);
+  return retValue;
 }
 
 template<typename IO, typename Rac, typename Coder>

--- a/src/flif-dec.hpp
+++ b/src/flif-dec.hpp
@@ -11,14 +11,24 @@ struct FLIF_INFO
     size_t num_images;
 };
 
+typedef struct callback_info_struct {
+  uint32_t quality;
+  int64_t  bytes_read;
+
+  // Private context
+  void *populateContext;
+} callback_info_t;
+
+typedef uint32_t (*callback_t)(callback_info_t *info, void *user_data);
+
 /*!
 * @param[out] info An info struct to fill. If this is not a null pointer, the decoding will exit after reading the file header.
 */
 
 template <typename IO>
-bool flif_decode(IO& io, Images &images, uint32_t (*callback)(int32_t,int64_t), int, Images &partial_images, flif_options &options, metadata_options &md, FLIF_INFO* info);
+bool flif_decode(IO& io, Images &images, callback_t callback, void *user_data, int, Images &partial_images, flif_options &options, metadata_options &md, FLIF_INFO* info);
 
 template <typename IO>
 bool flif_decode(IO& io, Images &images, flif_options &options, metadata_options &md) {
-    return flif_decode(io, images, NULL, 0, images, options, md, 0);
+    return flif_decode(io, images, NULL, NULL, 0, images, options, md, 0);
 }

--- a/src/library/flif-interface-private_dec.hpp
+++ b/src/library/flif-interface-private_dec.hpp
@@ -34,6 +34,7 @@ struct FLIF_DECODER
 
     flif_options options;
     void* callback;
+    void* user_data;
     int32_t first_quality;
     ~FLIF_DECODER() {
         // get rid of palettes

--- a/src/library/flif_dec.h
+++ b/src/library/flif_dec.h
@@ -25,6 +25,16 @@ limitations under the License.
 extern "C" {
 #endif // __cplusplus
 
+    typedef struct callback_info_struct {
+      uint32_t quality;
+      int64_t  bytes_read;
+
+      // Private context
+      void *populateContext;
+    } callback_info_t;
+
+    typedef uint32_t (*callback_t)(callback_info_t *info, void *user_data);
+
     typedef struct FLIF_DECODER FLIF_DECODER;
     typedef struct FLIF_INFO FLIF_INFO;
 
@@ -43,6 +53,8 @@ extern "C" {
     // returns a pointer to a given frame, counting from 0 (use index=0 for still images)
     FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_decoder_get_image(FLIF_DECODER* decoder, size_t index);
 
+    FLIF_DLLIMPORT void FLIF_API flif_decoder_generate_preview(callback_info_t *info);
+
     // release an decoder (has to be called after decoding is done, to avoid memory leaks)
     FLIF_DLLIMPORT void FLIF_API flif_destroy_decoder(FLIF_DECODER* decoder);
     // abort a decoder (can be used before decoding is completed)
@@ -58,7 +70,7 @@ extern "C" {
     // Progressive decoding: set a callback function. The callback will be called after a certain quality is reached,
     // and it should return the desired next quality that should be reached before it will be called again.
     // The qualities are expressed on a scale from 0 to 10000 (not 0 to 100!) for fine-grained control.
-    FLIF_DLLIMPORT void FLIF_API flif_decoder_set_callback(FLIF_DECODER* decoder, uint32_t (*callback)(int32_t quality, int64_t bytes_read));
+    FLIF_DLLIMPORT void FLIF_API flif_decoder_set_callback(FLIF_DECODER* decoder, callback_t callback, void *user_data);
     FLIF_DLLIMPORT void FLIF_API flif_decoder_set_first_callback_quality(FLIF_DECODER* decoder, int32_t quality); // valid quality: 0-10000
 
     // Reads the header of a FLIF file and packages it as a FLIF_INFO struct.

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -208,6 +208,7 @@ static int decodeThread(void * arg) {
     progressive_render(10000,-1);
 #endif
     flif_destroy_decoder(d);
+    d = NULL;
     return 0;
 }
 
@@ -255,10 +256,12 @@ int main(int argc, char **argv) {
         }
         while (SDL_PollEvent(&e)) do_event(e);
     }
+
     if (nb_frames > 1) printf("Rendered %i frames in %.2f seconds, %.4f frames per second\n", framecount, 0.001*(SDL_GetTicks()-begin), 1000.0*framecount/(SDL_GetTicks()-begin));
+
 #ifdef PROGRESSIVE_DECODING
     // make sure the decoding gets properly aborted (in case it was not done yet)
-    while(flif_abort_decoder(d)) SDL_Delay(100);
+    while(d != NULL && flif_abort_decoder(d)) SDL_Delay(100);
     SDL_WaitThread(decode_thread, &result);
 #endif
     SDL_DestroyWindow(window);


### PR DESCRIPTION
* Fixes a bug in viewflif : use of pointer after delete
* Adds a `void *user_data` parameter to the callback function. This allows, for example, C++ code to register a class member variable as a callback. C code can similarly benefit by having `user_data` point to a context holding structure. This avoid ugly hacks such as using global context for the callback.
* The creation of `partial_images` is now lazy. The callback function can now decide when to render the partial_images and thus when to create them.
* Since the number of parameters to the callback function has grown, and has some private members, I have created a structure `callback_info_t` to hold them.
* The above changes have changed the APIs related to callbacks. Does this require a bump of library version number?
* `viewflif` has been modified to work with the new API.
* I have run some benchmarks on small to medium images and measured improvements in overall decode times. The amount of improvement depends on the image, the quality threshold setting, the timeout for rendering the preview, etc. Seems to be in tune with what I would expect. However, I was not able to test with larger images; there are bugs in progressive decode logic (not related to these changes). I see the same bugs on master. One such bug is #381.

Closes #333 