### PR TITLE
Improve viewflif

### DIFF
--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -125,7 +125,7 @@ void FLIF_IMAGE::read_row_RGBA8(uint32_t row, void* buffer, size_t buffer_size_b
     int mult = 1;
     ColorVal m=image.max(0);
     while (m > 0xFF) { rshift++; m = m >> 1; } // in case the image has bit depth higher than 8
-    if (m < 0xFF) mult = 0xFF / m;
+    if ((m != 0) && m < 0xFF) mult = 0xFF / m;
     if (image.palette) {
       assert(image.numPlanes() >= 3);
       // always color
@@ -179,7 +179,7 @@ void FLIF_IMAGE::read_row_GRAY8(uint32_t row, void* buffer, size_t buffer_size_b
     int mult = 1;
     ColorVal m=image.max(0);
     while (m > 0xFF) { rshift++; m = m >> 1; } // in case the image has bit depth higher than 8
-    if (m < 0xFF) mult = 0xFF / m;
+    if ((m != 0) && m < 0xFF) mult = 0xFF / m;
 
     for (size_t c = 0; c < (size_t) image.cols(); c++) {
             buffer_gray[c] = ((image(0, row, c) >> rshift) * mult) & 0xFF;
@@ -227,7 +227,7 @@ void FLIF_IMAGE::read_row_RGBA16(uint32_t row, void* buffer, size_t buffer_size_
     int mult = 1;
     ColorVal m=image.max(0);
     while (m > 0xFFFF) { rshift++; m = m >> 1; } // in the unlikely case that the image has bit depth higher than 16
-    if (m < 0xFFFF) mult = 0xFFFF / m;
+    if ((m != 0) && m < 0xFFFF) mult = 0xFFFF / m;
 
     if(image.numPlanes() >= 3) {
         // color

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -177,6 +177,7 @@ bool updateTextures(uint32_t quality, int64_t bytes_read) {
     return true;
 }
 
+#ifdef PROGRESSIVE_DECODING
 // Callback function: converts (partially) decoded image/animation to a/several SDL_Texture(s),
 //                    resizes the viewer window if needed, and calls draw_image()
 // Input arguments are: quality (0..10000), current position in the .flif file
@@ -219,6 +220,7 @@ uint32_t progressive_render(callback_info_t *info, void *user_data) {
     }
 
 }
+#endif
 
 // When decoding progressively, this is a separate thread (so a partially loaded animation keeps playing while decoding more detail)
 static int decodeThread(void * arg) {

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -37,6 +37,7 @@ typedef struct RGBA { uint8_t r,g,b,a; } RGBA;
 FLIF_DECODER* d = NULL;
 SDL_Window* window = NULL;
 SDL_DisplayMode dm;
+SDL_DisplayMode ddm;
 SDL_Renderer* renderer = NULL;
 SDL_Texture** image_frame = NULL;
 SDL_Surface* decsurf = NULL;
@@ -207,7 +208,7 @@ static int decodeThread(void * arg) {
     // set the scale-down factor to 1 (a higher value will decode a downsampled preview)
     flif_decoder_set_scale(d, 1);                 // this is the default, so can be omitted
     // set the maximum size to twice the screen resolution; if an image is larger, a downsampled preview will be decoded
-    flif_decoder_set_resize(d, dm.w*2, dm.h*2);   // the default is to not have a maximum size
+    flif_decoder_set_resize(d, ddm.w*2, ddm.h*2);   // the default is to not have a maximum size
 
     // alternatively, set the decode width to exactly the screen width (the height will be set to respect aspect ratio)
     // flif_decoder_set_fit(d, dm.w, 0);   // the default is to not have a maximum size
@@ -242,10 +243,14 @@ int main(int argc, char **argv) {
     SDL_Init(SDL_INIT_VIDEO);
     SDL_EventState(SDL_MOUSEMOTION,SDL_IGNORE);
     window = SDL_CreateWindow("FLIF Viewer -- Loading...", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 200, 200, SDL_WINDOW_RESIZABLE);
+
     renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
     SDL_SetRenderDrawColor(renderer, 127, 127, 127, 255); // background color (in case aspect ratio of window doesn't match image)
     SDL_RenderClear(renderer);
     SDL_RenderPresent(renderer);
+
+    int displayIndex = SDL_GetWindowDisplayIndex(window);
+    if (SDL_GetDesktopDisplayMode(displayIndex,&ddm)) { printf("Error: SDL_GetWindowDisplayMode\n"); return 1; }
     if (SDL_GetWindowDisplayMode(window,&dm)) { printf("Error: SDL_GetWindowDisplayMode\n"); return 1; }
     int result = 0;
 #ifdef PROGRESSIVE_DECODING

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -106,7 +106,10 @@ int do_event(SDL_Event e) {
     return 1;
 }
 
-clock_t last_preview_time = -CLOCKS_PER_SEC;
+
+const double preview_interval= .6;
+
+clock_t last_preview_time = 0;
 
 // returns true on success
 bool updateTextures(uint32_t quality, int64_t bytes_read) {
@@ -189,7 +192,7 @@ uint32_t progressive_render(callback_info_t *info, void *user_data) {
 
       clock_t now = clock();
       double timeElapsed = ((double)(now - last_preview_time)) / CLOCKS_PER_SEC;
-      if (quality != 10000 && timeElapsed < 0.4) {
+      if (quality != 10000 && timeElapsed< preview_interval) {
         SDL_UnlockMutex(mutex);
         return quality + 1000;
       }
@@ -278,6 +281,8 @@ int main(int argc, char **argv) {
       fprintf(stderr, "Couldn't create mutex\n");
       return 1;
     }
+
+    last_preview_time = (-2*preview_interval* CLOCKS_PER_SEC);
 
     SDL_Init(SDL_INIT_VIDEO);
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "2");

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -241,6 +241,8 @@ int main(int argc, char **argv) {
     }
 
     SDL_Init(SDL_INIT_VIDEO);
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "2");
+
     SDL_EventState(SDL_MOUSEMOTION,SDL_IGNORE);
     window = SDL_CreateWindow("FLIF Viewer -- Loading...", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 200, 200, SDL_WINDOW_RESIZABLE);
 

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -303,8 +303,11 @@ int main(int argc, char **argv) {
     if (nb_frames > 1) printf("Rendered %i frames in %.2f seconds, %.4f frames per second\n", framecount, 0.001*(SDL_GetTicks()-begin), 1000.0*framecount/(SDL_GetTicks()-begin));
 
 #ifdef PROGRESSIVE_DECODING
-    // make sure the decoding gets properly aborted (in case it was not done yet)
-    while(d != NULL && flif_abort_decoder(d)) SDL_Delay(100);
+    if (SDL_LockMutex(mutex) == 0) {
+      // make sure the decoding gets properly aborted (in case it was not done yet)
+      while(d != NULL && flif_abort_decoder(d)) SDL_Delay(100);
+      SDL_UnlockMutex(mutex);
+    }
     SDL_WaitThread(decode_thread, &result);
 #endif
     SDL_DestroyWindow(window);

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -257,6 +257,15 @@ static int decodeThread(void * arg) {
     return 0;
 }
 
+bool abort_decode() {
+  if (SDL_LockMutex(mutex) == 0) {
+    int retValue = flif_abort_decoder(d);
+    SDL_UnlockMutex(mutex);
+    return retValue;
+  } else {
+    return false;
+  }
+}
 
 int main(int argc, char **argv) {
     if (argc < 2 || argc > 2) {
@@ -317,11 +326,8 @@ int main(int argc, char **argv) {
     if (nb_frames > 1) printf("Rendered %i frames in %.2f seconds, %.4f frames per second\n", framecount, 0.001*(SDL_GetTicks()-begin), 1000.0*framecount/(SDL_GetTicks()-begin));
 
 #ifdef PROGRESSIVE_DECODING
-    if (SDL_LockMutex(mutex) == 0) {
-      // make sure the decoding gets properly aborted (in case it was not done yet)
-      while(d != NULL && flif_abort_decoder(d)) SDL_Delay(100);
-      SDL_UnlockMutex(mutex);
-    }
+    // make sure the decoding gets properly aborted (in case it was not done yet)
+    while(d != NULL && abort_decode()) SDL_Delay(100);
     SDL_WaitThread(decode_thread, &result);
 #endif
     SDL_DestroyWindow(window);


### PR DESCRIPTION
* Use dimension of display to compute target resolution, instead of dimension of window, since window appears smaller at the beginning when the decode is started.
* Set `scale quality` to `best`
* Use SDL mutex to synchronize threads
* Fix a divide by zero error