### PR TITLE
#include <functional> to fix clang compile error

### DIFF
--- a/src/library/flif-interface_dec.cpp
+++ b/src/library/flif-interface_dec.cpp
@@ -19,6 +19,8 @@ limitations under the License.
 #include "flif-interface-private_dec.hpp"
 #include "flif-interface_common.cpp"
 
+#include <functional>
+
 FLIF_DECODER::FLIF_DECODER()
 : options(FLIF_DEFAULT_OPTIONS)
 , callback(NULL)


### PR DESCRIPTION
The current code is failing to be compiled on Clang because of this error:

```
In file included from submodules/flif/src/library/flif-interface.cpp:1:
submodules/flif/src/library/flif-interface_dec.cpp:250:27: error: no member named 'function' in namespace 'std'
        auto func = (std::function<void ()> *) info->populateContext;
                     ~~~~~^
submodules/flif/src/library/flif-interface_dec.cpp:250:46: error: expected expression
        auto func = (std::function<void ()> *) info->populateContext;
                                             ^
2 errors generated.
```

Including `<functional>` fixes this issue.