### PR TITLE
Simpler callback interface

### DIFF
--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -144,6 +144,10 @@ struct scanline_plane_decoder: public PlaneVisitor {
 //    void visit(ConstantPlane              &plane) override {flif_decode_scanline_plane(plane,coder,images,ranges,alpha,properties,p,fr,r,grey,minP,alphazero,FRA);}
 };
 
+uint32_t issue_callback(callback_t callback, void *user_data, uint32_t quality, int64_t bytes_read, bool decode_over, std::function<void ()> func) {
+  return callback(quality, bytes_read, decode_over ? 1 : 0, user_data, (void *) &func);
+}
+
 template<typename IO, typename Rac, typename Coder>
 bool flif_decode_scanlines_inner(IO &io, Rac &rac, std::vector<Coder> &coders, Images &images, const ColorRanges *ranges, int quality,
                                  std::vector<Transform<IO>*> &transforms, callback_t callback, void *user_data, Images &partial_images) {
@@ -214,10 +218,6 @@ bool flif_decode_scanlines_inner(IO &io, Rac &rac, std::vector<Coder> &coders, I
         }
     }
     return true;
-}
-
-uint32_t issue_callback(callback_t callback, void *user_data, uint32_t quality, int64_t bytes_read, bool decode_over, std::function<void ()> func) {
-  return callback(quality, bytes_read, decode_over ? 1 : 0, user_data, (void *) &func);
 }
 
 template<typename IO, typename Rac, typename Coder>

--- a/src/flif-dec.hpp
+++ b/src/flif-dec.hpp
@@ -11,15 +11,7 @@ struct FLIF_INFO
     size_t num_images;
 };
 
-typedef struct callback_info_struct {
-  uint32_t quality;
-  int64_t  bytes_read;
-
-  // Private context
-  void *populateContext;
-} callback_info_t;
-
-typedef uint32_t (*callback_t)(callback_info_t *info, void *user_data);
+typedef uint32_t (*callback_t)(uint32_t quality, int64_t bytes_read, uint8_t decode_over, void *user_data, void *context);
 
 /*!
 * @param[out] info An info struct to fill. If this is not a null pointer, the decoding will exit after reading the file header.

--- a/src/library/flif-interface_dec.cpp
+++ b/src/library/flif-interface_dec.cpp
@@ -246,10 +246,10 @@ FLIF_DLLEXPORT FLIF_IMAGE* FLIF_API flif_decoder_get_image(FLIF_DECODER* decoder
     return 0;
 }
 
-FLIF_DLLEXPORT void FLIF_API flif_decoder_generate_preview(callback_info_t *info) {
+FLIF_DLLEXPORT void FLIF_API flif_decoder_generate_preview(void *context) {
     try
     {
-        auto func = (std::function<void ()> *) info->populateContext;
+        auto func = (std::function<void ()> *) context;
         (*func)();
     }
     catch(...) {}

--- a/src/library/flif_dec.h
+++ b/src/library/flif_dec.h
@@ -25,15 +25,7 @@ limitations under the License.
 extern "C" {
 #endif // __cplusplus
 
-    typedef struct callback_info_struct {
-      uint32_t quality;
-      int64_t  bytes_read;
-
-      // Private context
-      void *populateContext;
-    } callback_info_t;
-
-    typedef uint32_t (*callback_t)(callback_info_t *info, void *user_data);
+    typedef uint32_t (*callback_t)(uint32_t quality, int64_t bytes_read, uint8_t decode_over, void *user_data, void *context);
 
     typedef struct FLIF_DECODER FLIF_DECODER;
     typedef struct FLIF_INFO FLIF_INFO;
@@ -53,7 +45,7 @@ extern "C" {
     // returns a pointer to a given frame, counting from 0 (use index=0 for still images)
     FLIF_DLLIMPORT FLIF_IMAGE* FLIF_API flif_decoder_get_image(FLIF_DECODER* decoder, size_t index);
 
-    FLIF_DLLIMPORT void FLIF_API flif_decoder_generate_preview(callback_info_t *info);
+    FLIF_DLLIMPORT void FLIF_API flif_decoder_generate_preview(void *context);
 
     // release an decoder (has to be called after decoding is done, to avoid memory leaks)
     FLIF_DLLIMPORT void FLIF_API flif_destroy_decoder(FLIF_DECODER* decoder);

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -185,11 +185,8 @@ clock_t last_preview_time = 0;
 //                    resizes the viewer window if needed, and calls draw_image()
 // Input arguments are: quality (0..10000), current position in the .flif file
 // Output is the desired minimal quality before doing the next callback
-uint32_t progressive_render(callback_info_t *info, void *user_data) {
+uint32_t progressive_render(uint32_t quality, int64_t bytes_read, uint8_t decode_over, void *user_data, void *context) {
     if (SDL_LockMutex(mutex) == 0) {
-
-      uint32_t quality = info->quality;
-
       clock_t now = clock();
       double timeElapsed = ((double)(now - last_preview_time)) / CLOCKS_PER_SEC;
       if (quality != 10000 && timeElapsed< preview_interval) {
@@ -197,12 +194,10 @@ uint32_t progressive_render(callback_info_t *info, void *user_data) {
         return quality + 1000;
       }
 
-      int64_t bytes_read = info->bytes_read;
-
       // For benchmarking
       // if (quality == 10000) printf("Total time: %.2lf\n", ((double)now ) / CLOCKS_PER_SEC);
 
-      flif_decoder_generate_preview(info);
+      flif_decoder_generate_preview(context);
 
       bool success = updateTextures(quality, bytes_read);
 

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -195,7 +195,8 @@ uint32_t progressive_render(uint32_t quality, int64_t bytes_read, uint8_t decode
       }
 
       // For benchmarking
-      // if (quality == 10000) printf("Total time: %.2lf\n", ((double)now ) / CLOCKS_PER_SEC);
+      // clock_t finalTime = clock();
+      // if (quality == 10000) printf("Total time: %.2lf\n", ((double)finalTime ) / CLOCKS_PER_SEC);
 
       flif_decoder_generate_preview(context);
 


### PR DESCRIPTION
* Avoid using structure to keep the API opaque
* Added a `decode_over` parameter to the callback, which indicates if decoding is over.
  Some clients can skip rendering the preview in that case.