### PR TITLE
WIP: Fast transforms for previews

### DIFF
--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -752,7 +752,7 @@ bool flif_decode_FLIF2_inner(IO& io, Rac &rac, std::vector<Coder> &coders, Image
 
             flif_decode_FLIF2_inner_interpol(partial_images, rangesCopy, 0, highestDecodedZL+1, -1, scale, zoomlevels_copy, transforms_copy);
 
-            const uint32_t zoomlevelScaled = highestDecodedZL + 1;// -(2*scale);
+            const uint32_t zoomlevelScaled = highestDecodedZL + 1 - (2*(scale - 1));
             const uint32_t strideRow = 1<<((zoomlevelScaled+1)/2);
             const uint32_t strideCol = 1<<((zoomlevelScaled)/2);
 

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -233,11 +233,27 @@ bool flif_decode_scanlines_pass(IO& io, Rac &rac, Images &images, const ColorRan
     return flif_decode_scanlines_inner<IO,Rac,Coder>(io, rac, coders, images, ranges, options.quality, transforms, callback, user_data, partial_images);
 }
 
+template<typename IO>
+const ColorRanges * undo_palette(Images &images, const int scale, std::vector<Transform<IO>*> &transforms, std::vector<int> &zoomlevels, const ColorRanges *ranges) {
+    if (images[0].palette && scale == 1) {
+      while(images[0].palette && transforms.size()>0) {
+        transforms.back()->invData(images);
+        transforms.pop_back();
+        ranges = ranges->previous();
+      }
+      zoomlevels[0] = zoomlevels[1];
+      zoomlevels[2] = zoomlevels[1];
+      if (zoomlevels.size() > 3) zoomlevels[3] = zoomlevels[1];
+    }
+
+    return ranges;
+}
+
 // interpolate rest of the image
 // used when decoding lossy
 template<typename IO>
 void flif_decode_FLIF2_inner_interpol(Images &images, const ColorRanges *ranges, const int P,
-                                      const int beginZL, const int endZL, const int32_t R, const int scale, std::vector<int> zoomlevels, std::vector<Transform<IO>*> &transforms) {
+                                      const int endZL, const int32_t R, const int scale, std::vector<int> &zoomlevels, std::vector<Transform<IO>*> &transforms) {
 
     // finish the zoomlevel we were working on
     if (R>=0) {
@@ -279,21 +295,15 @@ void flif_decode_FLIF2_inner_interpol(Images &images, const ColorRanges *ranges,
       }
     }
 
-    // undo palette before doing the rest of interpolation
-    if (images[0].palette && scale == 1) {
-      while(images[0].palette && transforms.size()>0) { transforms.back()->invData(images); transforms.pop_back(); ranges = ranges->previous();}
-      zoomlevels[0] = zoomlevels[1];
-      zoomlevels[2] = zoomlevels[1];
-      if (zoomlevels.size() > 3) zoomlevels[3] = zoomlevels[1];
-    }
+    ranges = undo_palette(images, scale, transforms, zoomlevels, ranges);
 
     // interpolate the next zoomlevels
     for (int p = 0; p < ranges->numPlanes() ; ) {
       int z = zoomlevels[p];
       if (z < endZL) { p++; continue; }
-      else zoomlevels[p]--;
-      if (ranges->min(p) >= ranges->max(p)) continue;
-      if ( p == 4 ) continue; // don't interpolate FRA lookback channel
+      zoomlevels[p]--;
+      if ( p == 4 ) { continue; }; // don't interpolate FRA lookback channel
+      if (ranges->min(p) >= ranges->max(p)) { continue; };
       if ( 1<<(z/2) < scale) continue;
       v_printf_tty(2,"\rINTERPOLATE[%i,%ux%u]                 ",p,images[0].cols(z),images[0].rows(z));
       v_printf_tty(5,"\n");
@@ -592,7 +602,7 @@ bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, Rac &rac, std::vect
 #ifdef CHECK_FOR_BROKENFILES
             if (io.isEOF()) {
               v_printf(1,"Row %i: Unexpected file end. Interpolation from now on.\n",r);
-              flif_decode_FLIF2_inner_interpol(images, ranges, p, beginZL, endZL, (r>1?r-2:r), scale, zoomlevels, transforms);
+              flif_decode_FLIF2_inner_interpol(images, ranges, p, endZL, (r>1?r-2:r), scale, zoomlevels, transforms);
               return false;
             }
 #endif
@@ -623,7 +633,7 @@ bool flif_decode_FLIF2_inner_vertical(const int p, IO& io, Rac &rac, std::vector
 #ifdef CHECK_FOR_BROKENFILES
             if (io.isEOF()) {
               v_printf(1,"Row %i: Unexpected file end. Interpolation from now on.\n", r);
-              flif_decode_FLIF2_inner_interpol(images, ranges, p, beginZL, endZL, (r>0?r-1:r), scale, zoomlevels, transforms);
+              flif_decode_FLIF2_inner_interpol(images, ranges, p, endZL, (r>0?r-1:r), scale, zoomlevels, transforms);
               return false;
             }
 #endif
@@ -680,7 +690,7 @@ bool flif_decode_FLIF2_inner(IO& io, Rac &rac, std::vector<Coder> &coders, Image
       if (z < 0) {e_printf("Corrupt file: invalid plane/zoomlevel\n"); return false;}
       if (100*pixels_done > quality*pixels_todo && endZL==0) {
               v_printf(5,"%lu subpixels done, %lu subpixels todo, quality target %i%% reached (%i%%)\n",(long unsigned)pixels_done,(long unsigned)pixels_todo,(int)quality,(int)(100*pixels_done/pixels_todo));
-              flif_decode_FLIF2_inner_interpol(images, ranges, p, beginZL, endZL, -1, scale, zoomlevels, transforms);
+              flif_decode_FLIF2_inner_interpol(images, ranges, p, endZL, -1, scale, zoomlevels, transforms);
               return false;
       }
       if (ranges->min(p) < ranges->max(p)) {
@@ -695,7 +705,7 @@ bool flif_decode_FLIF2_inner(IO& io, Rac &rac, std::vector<Coder> &coders, Image
         }
         if (1<<(z/2) < scale) {
               v_printf(5,"%lu subpixels done (out of %lu subpixels at this scale), scale target 1:%i reached\n",(long unsigned)pixels_done,(long unsigned)pixels_todo,scale);
-              flif_decode_FLIF2_inner_interpol(images, ranges, p, beginZL, endZL, -1, scale, zoomlevels, transforms);
+              flif_decode_FLIF2_inner_interpol(images, ranges, p, endZL, -1, scale, zoomlevels, transforms);
               return false;
         }
         if (endZL == 0) v_printf_tty(2,"\r%i%% done [%i/%i] DEC[%i,%ux%u]  ",(int)(100*pixels_done/pixels_todo),i,plane_zoomlevels(images[0], beginZL, endZL)-1,p,images[0].cols(z),images[0].rows(z));
@@ -733,24 +743,37 @@ bool flif_decode_FLIF2_inner(IO& io, Rac &rac, std::vector<Coder> &coders, Image
               partial_images[n] = Image(images[n], skipInterpolate.get(), zoomlevels); // make a skipped copy to work with
             }
 
-            int64_t pixels_really_done = pixels_done;
-
             std::vector<Transform<IO>*> transforms_copy = transforms;
             std::vector<int> zoomlevels_copy = zoomlevels;
-            flif_decode_FLIF2_inner_interpol(partial_images, ranges, 0, beginZL, endZL, -1, scale, zoomlevels_copy, transforms_copy);
+
+            const ColorRanges *rangesCopy = undo_palette(partial_images, scale, transforms_copy, zoomlevels_copy, ranges);
+
+            int highestDecodedZL = zoomlevels_copy[0];
+
+            flif_decode_FLIF2_inner_interpol(partial_images, rangesCopy, 0, highestDecodedZL+1, -1, scale, zoomlevels_copy, transforms_copy);
+
+            const uint32_t zoomlevelScaled = highestDecodedZL + 1;// -(2*scale);
+            const uint32_t strideRow = 1<<((zoomlevelScaled+1)/2);
+            const uint32_t strideCol = 1<<((zoomlevelScaled)/2);
+
+            for (int i=transforms_copy.size()-1; i>=0; i--) {
+              if (transforms_copy[i]->undo_redo_during_decode()) {
+                transforms_copy[i]->invData(partial_images, strideCol, strideRow);
+              }
+            }
+
+            int64_t pixels_really_done = pixels_done;
+
+            flif_decode_FLIF2_inner_interpol(partial_images, rangesCopy, 0, endZL, -1, scale, zoomlevels_copy, transforms_copy);
             if (endZL>0) {
-              flif_decode_FLIF2_inner_interpol(partial_images, ranges, 0, endZL-1, 0, -1, scale, zoomlevels_copy, transforms_copy);
+              flif_decode_FLIF2_inner_interpol(partial_images, rangesCopy, 0, 0, -1, scale, zoomlevels_copy, transforms_copy);
             }
             pixels_done = pixels_really_done;
             for (Image& image : partial_images) {
               image.normalize_scale();
             }
-            for (int i=transforms_copy.size()-1; i>=0; i--) {
-              if (transforms_copy[i]->undo_redo_during_decode()) {
-                transforms_copy[i]->invData(partial_images);
-              }
-            }
           };
+
           progressive_qual_shown = qual;
           progressive_qual_target = issue_callback(callback, user_data, qual, io.ftell(), false, populatePartialImages);
           if (qual >= progressive_qual_target) return false;
@@ -832,14 +855,14 @@ bool flif_decode_main(RacIn<IO>& rac, IO& io, Images &images, const ColorRanges 
 //      v_printf(2,"Decoding rough data\n");
       if (!flif_decode_FLIF2_pass<IO, RacIn<IO>, FinalPropertySymbolCoder<FLIFBitChancePass2, RacIn<IO>, bits> >(io, rac, images, ranges, forest, images[0].zooms(), roughZL+1, options, transforms, callback, user_data, partial_images)) {
         std::vector<int> zoomlevels(ranges->numPlanes(),roughZL);
-        flif_decode_FLIF2_inner_interpol(images, ranges, 0, roughZL, 0, -1, scale, zoomlevels, transforms);
+        flif_decode_FLIF2_inner_interpol(images, ranges, 0, 0, -1, scale, zoomlevels, transforms);
         return false;
       }
     }
     if (options.method.encoding == flifEncoding::interlaced && (options.quality <= 0 || pixels_done >= pixels_todo) && pixels_todo > 1) {
       v_printf(3,"Not decoding MANIAC tree (%i pixels done, had %i pixels to do)\n", pixels_done, pixels_todo);
       std::vector<int> zoomlevels(ranges->numPlanes(),roughZL);
-      flif_decode_FLIF2_inner_interpol(images, ranges, 0, roughZL, 0, -1, scale, zoomlevels, transforms);
+      flif_decode_FLIF2_inner_interpol(images, ranges, 0, 0, -1, scale, zoomlevels, transforms);
       return pixels_done >= pixels_todo;
     } else {
       v_printf(3,"Decoded header + rough data. Decoding MANIAC tree.\n");
@@ -847,7 +870,7 @@ bool flif_decode_main(RacIn<IO>& rac, IO& io, Images &images, const ColorRanges 
          if (options.method.encoding == flifEncoding::interlaced) {
             v_printf(1,"File probably truncated in the middle of MANIAC tree representation. Interpolating.\n");
             std::vector<int> zoomlevels(ranges->numPlanes(),roughZL);
-            flif_decode_FLIF2_inner_interpol(images, ranges, 0, roughZL, 0, -1, scale, zoomlevels, transforms);
+            flif_decode_FLIF2_inner_interpol(images, ranges, 0, 0, -1, scale, zoomlevels, transforms);
          }
          return false;
       }

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -909,6 +909,8 @@ public:
     uint32_t rows() const { return height; }
     uint32_t cols() const { return width; }
     int getscale() const { return scale; }
+    uint32_t scaledRows() const { return SCALED(height); }
+    uint32_t scaledCols() const { return SCALED(width); }
 
     // access pixel by zoomlevel coordinate
     static uint32_t zoom_rowpixelsize(int zoomlevel) {

--- a/src/transform/framecombine.hpp
+++ b/src/transform/framecombine.hpp
@@ -154,7 +154,7 @@ protected:
 #endif
 
     void configure(const int setting) override { user_max_lookback=nb_frames=setting; }
-    void invData(Images &images) const override {
+    void invData(Images &images, uint32_t strideCol, uint32_t strideRow) const override {
         // most work has to be done on the fly in the decoder, this is just some cleaning up
         for (Image& image : images) image.drop_frame_lookbacks();
         if (was_flat) for (Image& image : images) image.drop_alpha();

--- a/src/transform/palette.hpp
+++ b/src/transform/palette.hpp
@@ -84,21 +84,22 @@ public:
         int nb_colors = Palette_vector.size();
         return new ColorRangesPalette(srcRanges, nb_colors);
     }
-    void invData(Images& images) const override {
+    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
 //        v_printf(5,"invData Palette\n");
         for (Image& image : images) {
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
-          for (uint32_t r=0; r<image.rows(); r++) {
-            for (uint32_t c=0; c<image.cols(); c++) {
+          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
+            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
                 int P=image(1,r,c);
                 if (P < 0 || P >= (int) Palette_vector.size()) P = 0; // might happen on invisible pixels with predictor -H1
                 assert(P < (int) Palette_vector.size());
                 assert(P >= 0);
-                image.set(0,r,c, std::get<0>(Palette_vector[P]));
-                image.set(1,r,c, std::get<1>(Palette_vector[P]));
-                image.set(2,r,c, std::get<2>(Palette_vector[P]));
+                const Color &value = Palette_vector[P];
+                image.set(0,r,c, std::get<0>(value));
+                image.set(1,r,c, std::get<1>(value));
+                image.set(2,r,c, std::get<2>(value));
             }
           }
           image.palette=false;

--- a/src/transform/palette.hpp
+++ b/src/transform/palette.hpp
@@ -90,8 +90,12 @@ public:
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
-          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
-            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
+
+          const uint32_t scaledRows = image.scaledRows();
+          const uint32_t scaledCols = image.scaledCols();
+
+          for (uint32_t r=0; r<scaledRows; r+=strideRow) {
+            for (uint32_t c=0; c<scaledCols; c+=strideCol) {
                 int P=image(1,r,c);
                 if (P < 0 || P >= (int) Palette_vector.size()) P = 0; // might happen on invisible pixels with predictor -H1
                 assert(P < (int) Palette_vector.size());

--- a/src/transform/palette_A.hpp
+++ b/src/transform/palette_A.hpp
@@ -89,20 +89,21 @@ public:
         return new ColorRangesPaletteA(srcRanges, Palette_vector.size());
     }
 
-    void invData(Images& images) const override {
+    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         for (Image& image : images) {
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
           image.undo_make_constant_plane(3);
-          for (uint32_t r=0; r<image.rows(); r++) {
-            for (uint32_t c=0; c<image.cols(); c++) {
+          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
+            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
                 int P=image(1,r,c);
                 assert(P < (int) Palette_vector.size());
-                image.set(0,r,c, std::get<1>(Palette_vector[P]));
-                image.set(1,r,c, std::get<2>(Palette_vector[P]));
-                image.set(2,r,c, std::get<3>(Palette_vector[P]));
-                image.set(3,r,c, std::get<0>(Palette_vector[P]));
+                const Color &value = Palette_vector[P];
+                image.set(0,r,c, std::get<1>(value));
+                image.set(1,r,c, std::get<2>(value));
+                image.set(2,r,c, std::get<3>(value));
+                image.set(3,r,c, std::get<0>(value));
             }
           }
           image.palette=false;

--- a/src/transform/palette_A.hpp
+++ b/src/transform/palette_A.hpp
@@ -95,8 +95,12 @@ public:
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
           image.undo_make_constant_plane(3);
-          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
-            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
+
+          const uint32_t scaledRows = image.scaledRows();
+          const uint32_t scaledCols = image.scaledCols();
+
+          for (uint32_t r=0; r<scaledRows; r+=strideRow) {
+            for (uint32_t c=0; c<scaledCols; c+=strideCol) {
                 int P=image(1,r,c);
                 assert(P < (int) Palette_vector.size());
                 const Color &value = Palette_vector[P];

--- a/src/transform/palette_C.hpp
+++ b/src/transform/palette_C.hpp
@@ -70,16 +70,18 @@ public:
 
     void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         for (Image& image : images) {
+
+         const uint32_t scaledRows = image.scaledRows();
+         const uint32_t scaledCols = image.scaledCols();
+
          for (int p=0; p<image.numPlanes(); p++) {
           auto palette = CPalette_vector[p];
           auto palette_size = palette.size();
 //          const int stretch = (palette_size > 64 ? 0 : 2);
           image.undo_make_constant_plane(p);
           GeneralPlane &plane = image.getPlane(p);
-          uint32_t strideRowAdj = (p < 3) ? strideRow : 1;
-          uint32_t strideColAdj = (p < 3) ? strideCol : 1;
-          for (uint32_t r=0; r<image.rows(); r += strideRowAdj) {
-            for (uint32_t c=0; c<image.cols(); c += strideColAdj) {
+          for (uint32_t r=0; r<scaledRows; r ++) {
+            for (uint32_t c=0; c<scaledCols; c ++) {
                 int P=plane.get(r,c);
 //                image.set(p,r,c, palette[image(p,r,c) >> stretch]);
                 if (P < 0 || P >= (int) palette_size) P = 0; // might happen on invisible pixels with predictor -H1

--- a/src/transform/palette_C.hpp
+++ b/src/transform/palette_C.hpp
@@ -68,18 +68,23 @@ public:
         return new ColorRangesPaletteC(srcRanges, nb);
     }
 
-    void invData(Images& images) const override {
+    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         for (Image& image : images) {
          for (int p=0; p<image.numPlanes(); p++) {
-//          const int stretch = (CPalette_vector[p].size()>64 ? 0 : 2);
+          auto palette = CPalette_vector[p];
+          auto palette_size = palette.size();
+//          const int stretch = (palette_size > 64 ? 0 : 2);
           image.undo_make_constant_plane(p);
-          for (uint32_t r=0; r<image.rows(); r++) {
-            for (uint32_t c=0; c<image.cols(); c++) {
-                int P=image(p,r,c);
-//                image.set(p,r,c, CPalette_vector[p][image(p,r,c) >> stretch]);
-                if (P < 0 || P >= (int) CPalette_vector[p].size()) P = 0; // might happen on invisible pixels with predictor -H1
-                assert(P < (int) CPalette_vector[p].size());
-                image.set(p,r,c, CPalette_vector[p][P]);
+          GeneralPlane &plane = image.getPlane(p);
+          uint32_t strideRowAdj = (p < 3) ? strideRow : 1;
+          uint32_t strideColAdj = (p < 3) ? strideCol : 1;
+          for (uint32_t r=0; r<image.rows(); r += strideRowAdj) {
+            for (uint32_t c=0; c<image.cols(); c += strideColAdj) {
+                int P=plane.get(r,c);
+//                image.set(p,r,c, palette[image(p,r,c) >> stretch]);
+                if (P < 0 || P >= (int) palette_size) P = 0; // might happen on invisible pixels with predictor -H1
+                assert(P < (int) palette_size);
+                plane.set(r,c, palette[P]);
             }
           }
          }

--- a/src/transform/permute.hpp
+++ b/src/transform/permute.hpp
@@ -137,9 +137,13 @@ public:
     void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         ColorVal pixel[5];
         for (Image& image : images) {
+
+          const uint32_t scaledRows = image.scaledRows();
+          const uint32_t scaledCols = image.scaledCols();
+
           for (int p=0; p<ranges->numPlanes(); p++) image.undo_make_constant_plane(p);
-          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
-            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
+          for (uint32_t r=0; r<scaledRows; r+=strideRow) {
+            for (uint32_t c=0; c<scaledCols; c+=strideCol) {
                 for (int p=0; p<ranges->numPlanes(); p++) pixel[p] = image(p,r,c);
                 for (int p=0; p<ranges->numPlanes(); p++) image.set(permutation[p],r,c, pixel[p]);
                 image.set(permutation[0],r,c, pixel[0]);

--- a/src/transform/permute.hpp
+++ b/src/transform/permute.hpp
@@ -134,12 +134,12 @@ public:
         return true;
     }
 #define CLAMP(x,l,u) (x>u?u:(x<l?l:x))
-    void invData(Images& images) const override {
+    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         ColorVal pixel[5];
         for (Image& image : images) {
           for (int p=0; p<ranges->numPlanes(); p++) image.undo_make_constant_plane(p);
-          for (uint32_t r=0; r<image.rows(); r++) {
-            for (uint32_t c=0; c<image.cols(); c++) {
+          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
+            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
                 for (int p=0; p<ranges->numPlanes(); p++) pixel[p] = image(p,r,c);
                 for (int p=0; p<ranges->numPlanes(); p++) image.set(permutation[p],r,c, pixel[p]);
                 image.set(permutation[0],r,c, pixel[0]);

--- a/src/transform/transform.hpp
+++ b/src/transform/transform.hpp
@@ -49,6 +49,6 @@ public:
     void virtual data(Images&) const {}
 #endif
     const ColorRanges virtual *meta(Images&, const ColorRanges *srcRanges) { return new DupColorRanges(srcRanges); }
-    void virtual invData(Images&) const {}
+    void virtual invData(Images&, uint32_t strideCol=1, uint32_t strideRow=1) const {}
     bool virtual is_palette_transform() const { return false; }
 };

--- a/src/transform/yc1c2.hpp
+++ b/src/transform/yc1c2.hpp
@@ -110,8 +110,12 @@ public:
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
-          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
-            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
+
+          const uint32_t scaledRows = image.scaledRows();
+          const uint32_t scaledCols = image.scaledCols();
+
+          for (uint32_t r=0; r<scaledRows; r+=strideRow) {
+            for (uint32_t c=0; c<scaledCols; c+=strideCol) {
                 Y=image(0,r,c);
                 C1=image(1,r,c);
                 C2=image(2,r,c);

--- a/src/transform/yc1c2.hpp
+++ b/src/transform/yc1c2.hpp
@@ -103,15 +103,15 @@ public:
         }
     }
 #endif
-    void invData(Images& images) const override {
+    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         ColorVal R,G,B,Y,C1,C2;
         const ColorVal max[3] = {ranges->max(0), ranges->max(1), ranges->max(2)};
         for (Image& image : images) {
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
-          for (uint32_t r=0; r<image.rows(); r++) {
-            for (uint32_t c=0; c<image.cols(); c++) {
+          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
+            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
                 Y=image(0,r,c);
                 C1=image(1,r,c);
                 C2=image(2,r,c);

--- a/src/transform/ycocg.hpp
+++ b/src/transform/ycocg.hpp
@@ -225,7 +225,7 @@ public:
         }
     }
 #endif
-    void invData(Images& images) const override {
+    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
         const ColorVal max[3] = {ranges->max(0), ranges->max(1), ranges->max(2)};
         for (Image& image : images) {
           image.undo_make_constant_plane(0);
@@ -258,8 +258,8 @@ public:
           // general code, without SIMD
           {
           ColorVal R,G,B,Y,Co,Cg;
-          for (uint32_t r=0; r<image.rows(); r++) {
-            for (uint32_t c=0; c<image.cols(); c++) {
+          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
+            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
                 Y=image(0,r,c);
                 Co=image(1,r,c);
                 Cg=image(2,r,c);

--- a/src/transform/ycocg.hpp
+++ b/src/transform/ycocg.hpp
@@ -231,6 +231,10 @@ public:
           image.undo_make_constant_plane(0);
           image.undo_make_constant_plane(1);
           image.undo_make_constant_plane(2);
+
+          const uint32_t scaledRows = image.scaledRows();
+          const uint32_t scaledCols = image.scaledCols();
+
 #ifdef USE_SIMD
           // special case for 8-bit RGB decoding
           if (image.max(0) < 256) {
@@ -238,7 +242,7 @@ public:
             Plane<ColorVal_intern_16>& p1 = static_cast<Plane<ColorVal_intern_16>&>(image.getPlane(1));
             Plane<ColorVal_intern_16>& p2 = static_cast<Plane<ColorVal_intern_16>&>(image.getPlane(2));
             EightColorVals R,G,B,Y,Co,Cg;
-            for (uint32_t pos=0; pos < image.rows()*image.cols(); pos += 8) {
+            for (uint32_t pos=0; pos < scaledRows*scaledCols; pos += 8) {
                 Y = p0.get8(pos);
                 Co = p1.get8(pos);
                 Cg = p2.get8(pos);
@@ -258,8 +262,8 @@ public:
           // general code, without SIMD
           {
           ColorVal R,G,B,Y,Co,Cg;
-          for (uint32_t r=0; r<image.rows(); r+=strideRow) {
-            for (uint32_t c=0; c<image.cols(); c+=strideCol) {
+          for (uint32_t r=0; r<scaledRows; r+=strideRow) {
+            for (uint32_t c=0; c<scaledCols; c+=strideCol) {
                 Y=image(0,r,c);
                 Co=image(1,r,c);
                 Cg=image(2,r,c);


### PR DESCRIPTION
* First undo the palette transforms (same as current implementation)
* Then interpolate all planes to the same zoom level
* Then call `transform->invData()` with stride corresponding to that zoom level
* Then interpolate to zoom level 0

This works with all of the images I have tested, including stills / animations, with or without transparency, with or without scaling. I think it is stable. However, I request everyone to test this patch on different types of images.

Quick benchmark results are exciting. Will publish details soon.