### PR TITLE
Added decoding directly from a FILE* pointer to the API

### DIFF
--- a/src/library/flif-interface-private_dec.hpp
+++ b/src/library/flif-interface-private_dec.hpp
@@ -18,6 +18,8 @@ limitations under the License.
 
 #pragma once
 
+#include <stdio.h>
+
 #include "flif-interface-private_common.hpp"
 #include "../flif-dec.hpp"
 
@@ -26,6 +28,7 @@ struct FLIF_DECODER
     FLIF_DECODER();
 
     int32_t decode_file(const char* filename);
+    int32_t decode_filepointer(FILE *file, const char* filename);
     int32_t decode_memory(const void* buffer, size_t buffer_size_bytes);
     int32_t abort();
     size_t num_images();

--- a/src/library/flif-interface_dec.cpp
+++ b/src/library/flif-interface_dec.cpp
@@ -16,6 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <stdio.h>
+
 #include "flif-interface-private_dec.hpp"
 #include "flif-interface_common.cpp"
 
@@ -31,12 +33,17 @@ FLIF_DECODER::FLIF_DECODER()
 
 
 int32_t FLIF_DECODER::decode_file(const char* filename) {
-    internal_images.clear();
-    images.clear();
-
     FILE *file = fopen(filename,"rb");
     if(!file)
         return 0;
+
+    return decode_filepointer(file, filename);
+}
+
+int32_t FLIF_DECODER::decode_filepointer(FILE *file, const char *filename) {
+    internal_images.clear();
+    images.clear();
+
     FileIO fio(file, filename);
 
     working = true;
@@ -202,6 +209,20 @@ FLIF_DLLEXPORT int32_t FLIF_API flif_decoder_decode_file(FLIF_DECODER* decoder, 
     try
     {
         return decoder->decode_file(filename);
+    }
+    catch(...) {}
+    return 0;
+}
+
+/*!
+ * The filename here is used for error messages.
+ * It would be helpful to pass an actual filename here, but a non-NULL dummy one can be used instead.
+ * \return non-zero if the function succeeded
+ */
+FLIF_DLLEXPORT int32_t FLIF_API flif_decoder_decode_filepointer(FLIF_DECODER* decoder, FILE* filepointer, const char *filename) {
+    try
+    {
+        return decoder->decode_filepointer(filepointer, filename);
     }
     catch(...) {}
     return 0;

--- a/src/library/flif_dec.h
+++ b/src/library/flif_dec.h
@@ -19,6 +19,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <stdio.h>
+
 #include "flif_common.h"
 
 #ifdef __cplusplus
@@ -37,6 +39,13 @@ extern "C" {
     FLIF_DLLIMPORT int32_t FLIF_API flif_decoder_decode_file(FLIF_DECODER* decoder, const char* filename);
     // decode a FLIF blob in memory: buffer should point to the blob and buffer_size_bytes should be its size
     FLIF_DLLIMPORT int32_t FLIF_API flif_decoder_decode_memory(FLIF_DECODER* decoder, const void* buffer, size_t buffer_size_bytes);
+
+    /*
+    * Decode a given FLIF from a file pointer
+    * The filename here is used for error messages.
+    * It would be helpful to pass an actual filename here, but a non-NULL dummy one can be used instead.
+    */
+    FLIF_DLLIMPORT int32_t FLIF_API flif_decoder_decode_filepointer(FLIF_DECODER* decoder, FILE *filepointer, const char *filename);
 
     // returns the number of frames (1 if it is not an animation)
     FLIF_DLLIMPORT size_t FLIF_API flif_decoder_num_images(FLIF_DECODER* decoder);


### PR DESCRIPTION
This functionality is particularly useful because not all FILE* pointers were created from fopen to point to files on the hard drive. Some could be created by routines such as `tmpfile(3)` or `open_memstream(3)` and currently FLIF has no way of decoding them without buffering them into memory and using flif_decoder_decode_memory. This adds flif_decoder_decode_filepointer to the exported API. The caller still needs to pass a filename, but the filename can be any non-NULL string, because it's only used for the decoder to print error messages. A rich reader can give it a real name or a dummy name like "FilePointer."