### PR TITLE
Some fixes to the gdk-pixbuf loader

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 PREFIX := $(DESTDIR)/usr/local
-CXXFLAGS := $(shell pkg-config --cflags zlib libpng) -DLODEPNG_NO_COMPILE_PNG -DLODEPNG_NO_COMPILE_DISK
-CFLAGS := $(shell pkg-config --cflags zlib libpng) -DLODEPNG_NO_COMPILE_PNG -DLODEPNG_NO_COMPILE_DISK
-LDFLAGS := $(shell pkg-config --libs libpng)
+CXXFLAGS := $(CXXFLAGS) $(shell pkg-config --cflags zlib libpng) -DLODEPNG_NO_COMPILE_PNG -DLODEPNG_NO_COMPILE_DISK
+CFLAGS := $(CFLAGS) $(shell pkg-config --cflags zlib libpng) -DLODEPNG_NO_COMPILE_PNG -DLODEPNG_NO_COMPILE_DISK
+LDFLAGS := $(LDFLAGS) $(shell pkg-config --libs libpng)
 
 OSNAME := $(shell uname -s)
 SONAME = -soname

--- a/src/Makefile
+++ b/src/Makefile
@@ -99,6 +99,7 @@ install-libpixbufloader-flif$(LIBEXT): libpixbufloader-flif$(LIBEXT) install-lib
 	install -c -d /usr/lib/gdk-pixbuf-2.0/2.10.0/loaders
 	install -c -m 755 -s libpixbufloader-flif$(LIBEXT) /usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/
 	gdk-pixbuf-query-loaders --update-cache
+	xdg-mime install --novendor flif-mime.xml
 
 install-pixbufloader: install-libpixbufloader-flif$(LIBEXT)
 

--- a/src/flif-mime.xml
+++ b/src/flif-mime.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="image/flif">
+        <comment xml:lang="en">FLIF image</comment>
+        <magic priority="100">
+        	<match type="string" value="FLIF" offset="0"/>
+        </magic>
+        <glob pattern="*.flif"/>
+        <glob pattern="*.FLIF"/>
+  </mime-type>
+</mime-info>

--- a/src/flif-pixbuf-loader.c
+++ b/src/flif-pixbuf-loader.c
@@ -281,14 +281,15 @@ void fill_vtable (GdkPixbufModule *module) {
 }
 
 void fill_info (GdkPixbufFormat *info) {
+
     static GdkPixbufModulePattern signature[] = {
-            { "FLIF" }
+        { "FLIF", "    ", 100 },
+        { NULL, NULL, 0 }
     };
 
     static gchar *mime_types[] = {
             "image/flif",
             "image/x-flif",
-            "application/octet-stream", /* FIXME hack around systems missing mime type */
             NULL
     };
 


### PR DESCRIPTION
These are some changes pertaining to the gdk-pixbuf loader.

Using environmental `CFLAGS`, `CXXFLAGS`, and `LDFLAGS` also makes sense because users who do not have `/usr/local/lib` added to their `ld.so.conf` will want to specify their own `LDFLAGS` in order to tell `libpixbufloader-flif.so` where to find `libflif.so.0`. 