### PR TITLE
Use std::shared_ptr for image palette.

### DIFF
--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -1357,7 +1357,8 @@ bool flif_decode(IO& io, Images &images, callback_t callback, void *user_data, i
           transform_ptrs.back()->invData(palette);
           transform_ptrs.pop_back();
         }
-        for (Image& i : images) i.palette_image = make_unique<Image>(palette[0].clone());
+        std::shared_ptr<Image> p_image = std::make_shared<Image>(palette[0].clone());
+        for (Image& i : images) i.palette_image = p_image;
       }
     }
     transforms.clear();

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -1357,8 +1357,7 @@ bool flif_decode(IO& io, Images &images, callback_t callback, void *user_data, i
           transform_ptrs.back()->invData(palette);
           transform_ptrs.pop_back();
         }
-        Image *p_image = new Image(palette[0].clone());
-        for (Image& i : images) i.palette_image = p_image;
+        for (Image& i : images) i.palette_image = make_unique<Image>(palette[0].clone());
       }
     }
     transforms.clear();

--- a/src/image/image-png.cpp
+++ b/src/image/image-png.cpp
@@ -129,7 +129,7 @@ int image_load_png(const char *filename, Image &image, metadata_options &options
       png_get_PLTE(png_ptr,info_ptr, &palette,&nb_colors);
       png_bytep trans;
       png_get_tRNS(png_ptr,info_ptr, &trans,&nb_alpha, NULL);
-      image.palette_image = new Image(nb_colors,1,0,255,4);
+      image.palette_image = make_unique<Image>(nb_colors,1,0,255,4);
       for (int i=0; i<nb_colors; i++) {
         image.palette_image->set(0,0,i,palette[i].red);
         image.palette_image->set(1,0,i,palette[i].green);

--- a/src/image/image-png.cpp
+++ b/src/image/image-png.cpp
@@ -129,7 +129,7 @@ int image_load_png(const char *filename, Image &image, metadata_options &options
       png_get_PLTE(png_ptr,info_ptr, &palette,&nb_colors);
       png_bytep trans;
       png_get_tRNS(png_ptr,info_ptr, &trans,&nb_alpha, NULL);
-      image.palette_image = make_unique<Image>(nb_colors,1,0,255,4);
+      image.palette_image = std::make_shared<Image>(nb_colors,1,0,255,4);
       for (int i=0; i<nb_colors; i++) {
         image.palette_image->set(0,0,i,palette[i].red);
         image.palette_image->set(1,0,i,palette[i].green);

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -700,7 +700,7 @@ public:
 #endif
       frame_delay=0;
       palette=false;
-      palette_image.reset(nullptr);
+      palette_image.reset();
       alpha_zero_special=true;
       assert(min == 0);
       assert(max < (1<<depth));
@@ -771,7 +771,7 @@ public:
 
     void clear() {
         for (int p=0; p<5; p++) planes[p].reset(nullptr);
-        palette_image.reset(nullptr);
+        palette_image.reset();
     }
     void reset() {
         clear();

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -475,8 +475,8 @@ class Image {
       metadata = other.metadata;
       clear();
       palette = other.palette;
-      if (other.palette_image) palette_image = make_unique<Image>(other.palette_image->clone());
-      else palette_image.reset(nullptr);
+      // TODO: do we share the palette or clone it?
+      palette_image = other.palette_image;
       alpha_zero_special = other.alpha_zero_special;
       frame_delay = other.frame_delay;
       col_begin = other.col_begin;
@@ -512,7 +512,7 @@ class Image {
 
 public:
     bool palette;
-    std::unique_ptr<Image> palette_image;
+    std::shared_ptr<Image> palette_image;
     int frame_delay;
     bool alpha_zero_special = true;
     std::vector<uint32_t> col_begin;
@@ -592,8 +592,8 @@ public:
       depth = other.depth;
 #endif
       palette = other.palette;
-      if (other.palette_image) palette_image = make_unique<Image>(other.palette_image->clone());
-      else palette_image.reset(nullptr);
+      // TODO: do we share the palette or clone it?
+      palette_image = other.palette_image;
       alpha_zero_special = other.alpha_zero_special;
       frame_delay = other.frame_delay;
       // assume downsample is always able to allocate enough space
@@ -641,8 +641,8 @@ public:
       depth = other.depth;
 #endif
       palette = other.palette;
-      if (other.palette_image) palette_image = make_unique<Image>(other.palette_image->clone());
-      else palette_image.reset(nullptr);
+      // TODO: do we share the palette or clone it?
+      palette_image = other.palette_image;
       alpha_zero_special = other.alpha_zero_special;
       frame_delay = other.frame_delay;
       col_begin = other.col_begin;

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -444,8 +444,6 @@ struct metadata_options {
     bool xmp;
 };
 
-class Image;
-
 class Image {
     std::unique_ptr<GeneralPlane> planes[5]; // Red/Y, Green/Co, Blue/Cg, Alpha, Frame-Lookback(animation only)
     size_t width, height;
@@ -477,8 +475,8 @@ class Image {
       metadata = other.metadata;
       clear();
       palette = other.palette;
-      if (other.palette_image) palette_image = new Image(*other.palette_image);
-      else palette_image = NULL;
+      if (other.palette_image) palette_image = make_unique<Image>(other.palette_image->clone());
+      else palette_image.reset(nullptr);
       alpha_zero_special = other.alpha_zero_special;
       frame_delay = other.frame_delay;
       col_begin = other.col_begin;
@@ -514,7 +512,7 @@ class Image {
 
 public:
     bool palette;
-    Image * palette_image = NULL;
+    std::unique_ptr<Image> palette_image;
     int frame_delay;
     bool alpha_zero_special = true;
     std::vector<uint32_t> col_begin;
@@ -537,7 +535,6 @@ public:
       depth = 0;
 #endif
       palette = false;
-      palette_image = NULL;
       seen_before = 0;
     }
 
@@ -569,8 +566,7 @@ public:
       other.fully_decoded = false;
 
       palette = other.palette;
-      palette_image = other.palette_image;
-      other.palette_image = NULL;
+      palette_image = std::move(other.palette_image);
       alpha_zero_special = other.alpha_zero_special;
       col_begin = std::move(other.col_begin);
       col_end = std::move(other.col_end);
@@ -596,7 +592,8 @@ public:
       depth = other.depth;
 #endif
       palette = other.palette;
-      palette_image = other.palette_image;
+      if (other.palette_image) palette_image = make_unique<Image>(other.palette_image->clone());
+      else palette_image.reset(nullptr);
       alpha_zero_special = other.alpha_zero_special;
       frame_delay = other.frame_delay;
       // assume downsample is always able to allocate enough space
@@ -644,7 +641,8 @@ public:
       depth = other.depth;
 #endif
       palette = other.palette;
-      palette_image = other.palette_image;
+      if (other.palette_image) palette_image = make_unique<Image>(other.palette_image->clone());
+      else palette_image.reset(nullptr);
       alpha_zero_special = other.alpha_zero_special;
       frame_delay = other.frame_delay;
       col_begin = other.col_begin;
@@ -702,7 +700,7 @@ public:
 #endif
       frame_delay=0;
       palette=false;
-      palette_image = NULL;
+      palette_image.reset(nullptr);
       alpha_zero_special=true;
       assert(min == 0);
       assert(max < (1<<depth));
@@ -773,11 +771,7 @@ public:
 
     void clear() {
         for (int p=0; p<5; p++) planes[p].reset(nullptr);
-        if (palette_image) {
-//            printf("Deleting palette image\n");
-            delete palette_image;
-        }
-        palette_image = NULL;
+        palette_image.reset(nullptr);
     }
     void reset() {
         clear();

--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -563,7 +563,7 @@ FLIF_DLLEXPORT void FLIF_API flif_image_set_palette(FLIF_IMAGE* image, const voi
     {
         int nb = palette_size;
         image->image.palette = true;
-        image->image.palette_image = make_unique<Image>(nb,1,0,255,4);
+        image->image.palette_image = std::make_shared<Image>(nb,1,0,255,4);
         const FLIF_RGBA* buffer_rgba = reinterpret_cast<const FLIF_RGBA*>(buffer);
         for (int i=0; i<nb; i++) {
             image->image.palette_image->set(0,0,i,buffer_rgba[i].r);

--- a/src/library/flif-interface_common.cpp
+++ b/src/library/flif-interface_common.cpp
@@ -563,8 +563,7 @@ FLIF_DLLEXPORT void FLIF_API flif_image_set_palette(FLIF_IMAGE* image, const voi
     {
         int nb = palette_size;
         image->image.palette = true;
-        if (image->image.palette_image) delete image->image.palette_image;
-        image->image.palette_image = new Image(nb,1,0,255,4);
+        image->image.palette_image = make_unique<Image>(nb,1,0,255,4);
         const FLIF_RGBA* buffer_rgba = reinterpret_cast<const FLIF_RGBA*>(buffer);
         for (int i=0; i<nb; i++) {
             image->image.palette_image->set(0,0,i,buffer_rgba[i].r);


### PR DESCRIPTION
Hello,

The current implementation of `image_palette` uses a raw `Image` pointer, but a `unique_ptr` would be safer and enforce strict ownership rules.

In particular, transfer of ownership looks unclear to me in *downsampling copy constructor* https://github.com/FLIF-hub/FLIF/blob/master/src/image/image.hpp#L599 and *copy constructor with stride* https://github.com/FLIF-hub/FLIF/blob/master/src/image/image.hpp#L647 Using a `unique_ptr` detects this bug, so I used a `clone()` here instead. But maybe a `shared_ptr` would be more appropriate for palettes?