### PR TITLE
Set standard streams from text mode to binary mode on Windows.

### DIFF
--- a/src/flif.cpp
+++ b/src/flif.cpp
@@ -50,6 +50,11 @@
 #define strcasecmp _stricmp
 #endif
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 // planes:
 // 0    Y channel (luminance)
 // 1    I (chroma)
@@ -457,6 +462,11 @@ int handle_decode(int argc, char **argv, Images &images, flif_options &options) 
 int main(int argc, char **argv) {
     Images images;
     flif_options options = FLIF_DEFAULT_OPTIONS;
+#ifdef _WIN32
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+    _setmode(_fileno(stderr), _O_BINARY);
+#endif
 #ifdef HAS_ENCODER
     int mode = -1; // 0 = encode, 1 = decode, 2 = transcode
 #else

--- a/src/image/image-pam.cpp
+++ b/src/image/image-pam.cpp
@@ -2,11 +2,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
 
 #include "image.hpp"
 #include "image-pam.hpp"
@@ -108,7 +103,7 @@ bool image_save_pam(const char *filename, const Image& image)
 {
     if (image.numPlanes() < 4) return image_save_pnm(filename, image);
     FILE *fp = NULL;
-    if (!strcmp(filename,"-")) fp = fdopen(dup(fileno(stdout)), "wb"); // make sure it is in binary mode (needed in Windows)
+    if (!strcmp(filename,"-")) fp = stdout;
     else fp = fopen(filename,"wb");
     if (!fp) {
         return false;

--- a/src/image/image-pnm.cpp
+++ b/src/image/image-pnm.cpp
@@ -2,11 +2,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
 
 #include "image.hpp"
 #include "image-pnm.hpp"
@@ -33,7 +28,7 @@ unsigned int read_pnm_int(FILE *fp, char* buf, char** t) {
 
 bool image_load_pnm(const char *filename, Image& image) {
     FILE *fp = NULL;
-    if (!strcmp(filename,"-")) fp = fdopen(dup(fileno(stdin)), "rb"); // make sure it is in binary mode (needed in Windows)
+    if (!strcmp(filename,"-")) fp = stdin;
     else fp = fopen(filename,"rb");
 
     char buf[PPMREADBUFLEN], *t;
@@ -120,7 +115,7 @@ bool image_load_pnm(const char *filename, Image& image) {
 bool image_save_pnm(const char *filename, const Image& image)
 {
     FILE *fp = NULL;
-    if (!strcmp(filename,"-")) fp = fdopen(dup(fileno(stdout)), "wb"); // make sure it is in binary mode (needed in Windows)
+    if (!strcmp(filename,"-")) fp = stdout;
     else fp = fopen(filename,"wb");
     if (!fp) {
         return false;


### PR DESCRIPTION
Now, pipeline on Windows should work.
Fix #341, and actually stdout on Windows also gets wrong result.

  