### PR TITLE
Fix bash-completion treatment of existing arguments containing spaces.

### DIFF
--- a/debian/flif.bash-completion
+++ b/debian/flif.bash-completion
@@ -10,7 +10,7 @@ _flif()
     base_name=output
 
     # scan the previous arguments to guess what we are doing: encoding or decoding?
-    for pw in ${words[@]:1:$(($cword - 1))}; do
+    for pw in "${words[@]:1:$((cword - 1))}"; do
         case $pw in
             -d|--decode)
                 action=decode
@@ -35,8 +35,8 @@ _flif()
                     unknown|decode)
                         action=decode
                         base_name=$pw
-                        base_name=$(basename $base_name .flif)
-                        base_name=$(basename $base_name .flf)
+                        base_name=$(basename "$base_name" .flif)
+                        base_name=$(basename "$base_name" .flf)
                         case $next_arg_needed in
                             flif|unknown)
                                 next_arg_needed=nonflif
@@ -52,8 +52,8 @@ _flif()
                             flif)
                                 next_arg_needed=flif2
                                 base_name=$pw
-                                base_name=$(basename $base_name .flif)
-                                base_name=$(basename $base_name .flf)
+                                base_name=$(basename "$base_name" .flif)
+                                base_name=$(basename "$base_name" .flf)
                                 base_name="$base_name-transcoded"
                                 ;;
                             flif2)
@@ -72,13 +72,13 @@ _flif()
                         action=encode
                         next_arg_needed=flif
                         base_name=$pw
-                        base_name=$(basename $base_name .png)
-                        base_name=$(basename $base_name .pnm)
-                        base_name=$(basename $base_name .pam)
-                        base_name=$(basename $base_name .ppm)
-                        base_name=$(basename $base_name .pgm)
-                        base_name=$(basename $base_name .pbm)
-                        base_name=$(basename $base_name .rggb)
+                        base_name=$(basename "$base_name" .png)
+                        base_name=$(basename "$base_name" .pnm)
+                        base_name=$(basename "$base_name" .pam)
+                        base_name=$(basename "$base_name" .ppm)
+                        base_name=$(basename "$base_name" .pgm)
+                        base_name=$(basename "$base_name" .pbm)
+                        base_name=$(basename "$base_name" .rggb)
                         ;;
                     decode)
                         next_arg_needed=none


### PR DESCRIPTION
Currently a few things aren't quoted properly, such that when the function is performing completion by e.g. suggesting an output filename by taking the input filename and changing its extension, if the filename contains a space, all but the last space-separated component will get cut off (e.g. "flif -e haggard\ beavis\ egg.png " + TAB will fill in "egg.flif" as the next argument).