### PR TITLE
Fixes for most compiler warnings using GCC 7.3.0 and mingw-w64.

### DIFF
--- a/build/MSVC/getopt/getopt.c
+++ b/build/MSVC/getopt/getopt.c
@@ -227,8 +227,8 @@ int _getopt_internal_r_a (int argc, char *const *argv, const char *optstring, co
 					ambig_list = newp;
 				}
 			}
-			if (ambig_list != NULL && !exact)
-			{
+		if (ambig_list != NULL && !exact)
+		{
 				if (print_errors)
 				{
 					struct option_list first;
@@ -248,76 +248,76 @@ int _getopt_internal_r_a (int argc, char *const *argv, const char *optstring, co
 				d->optind++;
 				d->optopt = 0;
 				return '?';
-			}
-			if (pfound != NULL)
+		}
+		if (pfound != NULL)
+		{
+			option_index = indfound;
+			d->optind++;
+			if (*nameend)
 			{
-				option_index = indfound;
-				d->optind++;
-				if (*nameend)
+				if (pfound->has_arg)
+					d->optarg = nameend + 1;
+				else
 				{
-					if (pfound->has_arg)
-						d->optarg = nameend + 1;
-					else
+					if (print_errors)
 					{
-						if (print_errors)
+						if (argv[d->optind - 1][1] == '-')
 						{
-							if (argv[d->optind - 1][1] == '-')
-							{
-								fprintf(stderr, "%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
-							}
-							else
-							{
-								fprintf(stderr, "%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
-							}
+							fprintf(stderr, "%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
 						}
-						d->__nextchar += strlen(d->__nextchar);
-						d->optopt = pfound->val;
-						return '?';
-					}
-				}
-				else if (pfound->has_arg == 1)
-				{
-					if (d->optind < argc)
-						d->optarg = argv[d->optind++];
-					else
-					{
-						if (print_errors)
+						else
 						{
-							fprintf(stderr,"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
+							fprintf(stderr, "%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
 						}
-						d->__nextchar += strlen(d->__nextchar);
-						d->optopt = pfound->val;
-						return optstring[0] == ':' ? ':' : '?';
 					}
+					d->__nextchar += strlen(d->__nextchar);
+					d->optopt = pfound->val;
+					return '?';
 				}
-				d->__nextchar += strlen(d->__nextchar);
-				if (longind != NULL)
-					*longind = option_index;
-				if (pfound->flag)
-				{
-					*(pfound->flag) = pfound->val;
-					return 0;
-				}
-				return pfound->val;
 			}
-			if (!long_only || argv[d->optind][1] == '-' || strchr(optstring, *d->__nextchar) == NULL)
+			else if (pfound->has_arg == 1)
 			{
-				if (print_errors)
+				if (d->optind < argc)
+					d->optarg = argv[d->optind++];
+				else
 				{
-					if (argv[d->optind][1] == '-')
+					if (print_errors)
 					{
-						fprintf(stderr, "%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+						fprintf(stderr,"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
 					}
-					else
-					{
-						fprintf(stderr, "%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
-					}
+					d->__nextchar += strlen(d->__nextchar);
+					d->optopt = pfound->val;
+					return optstring[0] == ':' ? ':' : '?';
 				}
-				d->__nextchar = (char *)"";
-				d->optind++;
-				d->optopt = 0;
-				return '?';
 			}
+			d->__nextchar += strlen(d->__nextchar);
+			if (longind != NULL)
+				*longind = option_index;
+			if (pfound->flag)
+			{
+				*(pfound->flag) = pfound->val;
+				return 0;
+			}
+			return pfound->val;
+		}
+		if (!long_only || argv[d->optind][1] == '-' || strchr(optstring, *d->__nextchar) == NULL)
+		{
+			if (print_errors)
+			{
+				if (argv[d->optind][1] == '-')
+				{
+					fprintf(stderr, "%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+				}
+				else
+				{
+					fprintf(stderr, "%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
+				}
+			}
+			d->__nextchar = (char *)"";
+			d->optind++;
+			d->optopt = 0;
+			return '?';
+		}
 	}
 	{
 		char c = *d->__nextchar++;
@@ -383,62 +383,62 @@ int _getopt_internal_r_a (int argc, char *const *argv, const char *optstring, co
 					else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
 						ambig = 1;
 				}
-				if (ambig && !exact)
+			if (ambig && !exact)
+			{
+				if (print_errors)
 				{
-					if (print_errors)
-					{
-						fprintf(stderr, "%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
-					}
-					d->__nextchar += strlen(d->__nextchar);
-					d->optind++;
-					return '?';
+					fprintf(stderr, "%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
 				}
-				if (pfound != NULL)
+				d->__nextchar += strlen(d->__nextchar);
+				d->optind++;
+				return '?';
+			}
+			if (pfound != NULL)
+			{
+				option_index = indfound;
+				if (*nameend)
 				{
-					option_index = indfound;
-					if (*nameend)
-					{
-						if (pfound->has_arg)
-							d->optarg = nameend + 1;
-						else
-						{
-							if (print_errors)
-							{
-								fprintf(stderr, "%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
-							}
-							d->__nextchar += strlen(d->__nextchar);
-							return '?';
-						}
-					}
-					else if (pfound->has_arg == 1)
-					{
-						if (d->optind < argc)
-							d->optarg = argv[d->optind++];
-						else
-						{
-							if (print_errors)
-							{
-								fprintf(stderr, "%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
-							}
-							d->__nextchar += strlen(d->__nextchar);
-							return optstring[0] == ':' ? ':' : '?';
-						}
-					}
+					if (pfound->has_arg)
+						d->optarg = nameend + 1;
 					else
-						d->optarg = NULL;
-					d->__nextchar += strlen(d->__nextchar);
-					if (longind != NULL)
-						*longind = option_index;
-					if (pfound->flag)
 					{
-						*(pfound->flag) = pfound->val;
-						return 0;
+						if (print_errors)
+						{
+							fprintf(stderr, "%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += strlen(d->__nextchar);
+						return '?';
 					}
-					return pfound->val;
 				}
+				else if (pfound->has_arg == 1)
+				{
+					if (d->optind < argc)
+						d->optarg = argv[d->optind++];
+					else
+					{
+						if (print_errors)
+						{
+							fprintf(stderr, "%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += strlen(d->__nextchar);
+						return optstring[0] == ':' ? ':' : '?';
+					}
+				}
+				else
+					d->optarg = NULL;
+				d->__nextchar += strlen(d->__nextchar);
+				if (longind != NULL)
+					*longind = option_index;
+				if (pfound->flag)
+				{
+					*(pfound->flag) = pfound->val;
+					return 0;
+				}
+				return pfound->val;
+			}
 no_longs:
-				d->__nextchar = NULL;
-				return 'W';
+			d->__nextchar = NULL;
+			return 'W';
 		}
 		if (temp[1] == ':')
 		{
@@ -687,97 +687,97 @@ int _getopt_internal_r_w (int argc, wchar_t *const *argv, const wchar_t *optstri
 					ambig_list = newp;
 				}
 			}
-			if (ambig_list != NULL && !exact)
-			{
-				if (print_errors)
-				{						
-					struct option_list first;
-					first.p = pfound;
-					first.next = ambig_list;
-					ambig_list = &first;
-					fwprintf(stderr, L"%s: option '%s' is ambiguous; possibilities:", argv[0], argv[d->optind]);
-					do
-					{
-						fwprintf (stderr, L" '--%s'", ambig_list->p->name);
-						ambig_list = ambig_list->next;
-					}
-					while (ambig_list != NULL);
-					fputwc (L'\n', stderr);
-				}
-				d->__nextchar += wcslen(d->__nextchar);
-				d->optind++;
-				d->optopt = 0;
-				return L'?';
-			}
-			if (pfound != NULL)
-			{
-				option_index = indfound;
-				d->optind++;
-				if (*nameend)
+		if (ambig_list != NULL && !exact)
+		{
+			if (print_errors)
+			{						
+				struct option_list first;
+				first.p = pfound;
+				first.next = ambig_list;
+				ambig_list = &first;
+				fwprintf(stderr, L"%s: option '%s' is ambiguous; possibilities:", argv[0], argv[d->optind]);
+				do
 				{
-					if (pfound->has_arg)
-						d->optarg = nameend + 1;
-					else
+					fwprintf (stderr, L" '--%s'", ambig_list->p->name);
+					ambig_list = ambig_list->next;
+				}
+				while (ambig_list != NULL);
+				fputwc (L'\n', stderr);
+			}
+			d->__nextchar += wcslen(d->__nextchar);
+			d->optind++;
+			d->optopt = 0;
+			return L'?';
+		}
+		if (pfound != NULL)
+		{
+			option_index = indfound;
+			d->optind++;
+			if (*nameend)
+			{
+				if (pfound->has_arg)
+					d->optarg = nameend + 1;
+				else
+				{
+					if (print_errors)
 					{
-						if (print_errors)
+						if (argv[d->optind - 1][1] == L'-')
 						{
-							if (argv[d->optind - 1][1] == L'-')
-							{
-								fwprintf(stderr, L"%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
-							}
-							else
-							{
-								fwprintf(stderr, L"%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
-							}
+							fwprintf(stderr, L"%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
 						}
-						d->__nextchar += wcslen(d->__nextchar);
-						d->optopt = pfound->val;
-						return L'?';
-					}
-				}
-				else if (pfound->has_arg == 1)
-				{
-					if (d->optind < argc)
-						d->optarg = argv[d->optind++];
-					else
-					{
-						if (print_errors)
+						else
 						{
-							fwprintf(stderr,L"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
+							fwprintf(stderr, L"%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
 						}
-						d->__nextchar += wcslen(d->__nextchar);
-						d->optopt = pfound->val;
-						return optstring[0] == L':' ? L':' : L'?';
 					}
+					d->__nextchar += wcslen(d->__nextchar);
+					d->optopt = pfound->val;
+					return L'?';
 				}
-				d->__nextchar += wcslen(d->__nextchar);
-				if (longind != NULL)
-					*longind = option_index;
-				if (pfound->flag)
-				{
-					*(pfound->flag) = pfound->val;
-					return 0;
-				}
-				return pfound->val;
 			}
-			if (!long_only || argv[d->optind][1] == L'-' || wcschr(optstring, *d->__nextchar) == NULL)
+			else if (pfound->has_arg == 1)
 			{
-				if (print_errors)
+				if (d->optind < argc)
+					d->optarg = argv[d->optind++];
+				else
 				{
-					if (argv[d->optind][1] == L'-')
+					if (print_errors)
 					{
-						fwprintf(stderr, L"%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+						fwprintf(stderr,L"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
 					}
-					else
-					{
-						fwprintf(stderr, L"%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
-					}
+					d->__nextchar += wcslen(d->__nextchar);
+					d->optopt = pfound->val;
+					return optstring[0] == L':' ? L':' : L'?';
 				}
-				d->__nextchar = (wchar_t *)L"";
-				d->optind++;
-				d->optopt = 0;
-				return L'?';
 			}
+			d->__nextchar += wcslen(d->__nextchar);
+			if (longind != NULL)
+				*longind = option_index;
+			if (pfound->flag)
+			{
+				*(pfound->flag) = pfound->val;
+				return 0;
+			}
+			return pfound->val;
+		}
+		if (!long_only || argv[d->optind][1] == L'-' || wcschr(optstring, *d->__nextchar) == NULL)
+		{
+			if (print_errors)
+			{
+				if (argv[d->optind][1] == L'-')
+				{
+					fwprintf(stderr, L"%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+				}
+				else
+				{
+					fwprintf(stderr, L"%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
+				}
+			}
+			d->__nextchar = (wchar_t *)L"";
+			d->optind++;
+			d->optopt = 0;
+			return L'?';
+		}
 	}
 	{
 		wchar_t c = *d->__nextchar++;
@@ -843,8 +843,8 @@ int _getopt_internal_r_w (int argc, wchar_t *const *argv, const wchar_t *optstri
 					else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
 						ambig = 1;
 				}
-				if (ambig && !exact)
-				{
+			if (ambig && !exact)
+			{
 					if (print_errors)
 					{
 						fwprintf(stderr, L"%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
@@ -852,53 +852,53 @@ int _getopt_internal_r_w (int argc, wchar_t *const *argv, const wchar_t *optstri
 					d->__nextchar += wcslen(d->__nextchar);
 					d->optind++;
 					return L'?';
-				}
-				if (pfound != NULL)
+			}
+			if (pfound != NULL)
+			{
+				option_index = indfound;
+				if (*nameend)
 				{
-					option_index = indfound;
-					if (*nameend)
-					{
-						if (pfound->has_arg)
-							d->optarg = nameend + 1;
-						else
-						{
-							if (print_errors)
-							{
-								fwprintf(stderr, L"%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
-							}
-							d->__nextchar += wcslen(d->__nextchar);
-							return L'?';
-						}
-					}
-					else if (pfound->has_arg == 1)
-					{
-						if (d->optind < argc)
-							d->optarg = argv[d->optind++];
-						else
-						{
-							if (print_errors)
-							{
-								fwprintf(stderr, L"%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
-							}
-							d->__nextchar += wcslen(d->__nextchar);
-							return optstring[0] == L':' ? L':' : L'?';
-						}
-					}
+					if (pfound->has_arg)
+						d->optarg = nameend + 1;
 					else
-						d->optarg = NULL;
-					d->__nextchar += wcslen(d->__nextchar);
-					if (longind != NULL)
-						*longind = option_index;
-					if (pfound->flag)
 					{
-						*(pfound->flag) = pfound->val;
-						return 0;
+						if (print_errors)
+						{
+							fwprintf(stderr, L"%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += wcslen(d->__nextchar);
+						return L'?';
 					}
-					return pfound->val;
 				}
+				else if (pfound->has_arg == 1)
+				{
+					if (d->optind < argc)
+						d->optarg = argv[d->optind++];
+					else
+					{
+						if (print_errors)
+						{
+							fwprintf(stderr, L"%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += wcslen(d->__nextchar);
+						return optstring[0] == L':' ? L':' : L'?';
+					}
+				}
+				else
+					d->optarg = NULL;
+				d->__nextchar += wcslen(d->__nextchar);
+				if (longind != NULL)
+					*longind = option_index;
+				if (pfound->flag)
+				{
+					*(pfound->flag) = pfound->val;
+					return 0;
+				}
+				return pfound->val;
+			}
 no_longs:
-				d->__nextchar = NULL;
-				return L'W';
+			d->__nextchar = NULL;
+			return L'W';
 		}
 		if (temp[1] == L':')
 		{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,16 +92,39 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
     if(WIN32)
 #This is neeeded to prevent warnings such as:
 #mingw The ABI for passing parameters with 16-byte alignment has changed in GCC 4.6
 #if you compile for i686.
 #but the downside is that the compiled binaries might not work with some old CPU's.
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mavx")
     endif(WIN32)
     set(CMAKE_CXX_FLAGS_DEBUG "-ggdb3")
+    set(CMAKE_C_FLAGS_DEBUG "-ggdb3")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ftree-vectorize")
-endif()
+    set(CMAKE_C_FLAGS_RELEASE "-O3 -ftree-vectorize")
+else()
+# Clang specific things
+# from: https://stackoverflow.com/questions/10046114/in-cmake-how-can-i-test-if-the-compiler-is-clang
+    if (CMAKE_CXX_COMPILER_ID MATCHES "[cC][lL][aA][nN][gG]") #Case insensitive match
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+       if(WIN32)
+#This is neeeded to prevent warnings such as:
+#mingw The ABI for passing parameters with 16-byte alignment has changed in GCC 4.6
+#if you compile for i686.
+#but the downside is that the compiled binaries might not work with some old CPU's.
+          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+          set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mavx")
+      endif(WIN32)
+      set(CMAKE_CXX_FLAGS_DEBUG "-ggdb3")
+      set(CMAKE_C_FLAGS_DEBUG "-ggdb3")
+      set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ftree-vectorize")
+      set(CMAKE_C_FLAGS_RELEASE "-O3 -ftree-vectorize")
+    endif(CMAKE_CXX_COMPILER_ID MATCHES "[cC][lL][aA][nN][gG]") #Case insensitive match
+endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(USE_ASAN)
     message(STATUS "Using ASAN")
@@ -139,7 +162,6 @@ endif()
 if(BUILD_SHARED_LIBS)
     add_library(flif_lib SHARED ${COMMON_SOURCES} ${FLIF_ENC_FILES})
     add_library(flif_lib_dec SHARED ${COMMON_SOURCES} ${FLIF_DEC_FILES} ${FLIF_DEC_HEADERS})
-#${FLIF_SRC_DIR}/library/flif-interface_dec.cpp)
 
     target_link_libraries(flif_lib ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
     target_link_libraries(flif_lib_dec ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
@@ -289,7 +311,6 @@ if(${SDL2_FOUND} AND ${BUILD_SHARED_LIBS})
     else(WIN32)
       add_executable(viewflif ${FLIF_SRC_DIR}/viewflif.c)
     endif(WIN32)
-    set_source_files_properties(${FLIF_SRC_DIR}/viewflif.c PROPERTIES LANGUAGE CXX)
     if ("${PKG_SDL2_STATIC_LIBRARIES}" STREQUAL "")
       target_link_libraries(viewflif flif_lib_dec ${SDL2_LIBRARY} ${SDL2MAIN_LIBRARY})
     else("${PKG_SDL2_STATIC_LIBRARIES}" STREQUAL "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(flif)
 
+include(GNUInstallDirs)
+include(FindPkgConfig)
 find_package(PNG REQUIRED)
 include_directories(${PNG_INCLUDE_DIRS})
+option(BUILD_SHARED_LIBS "Build shared FLIF encoder/decoder libraries" ON)
+option(BUILD_STATIC_LIBS "Build static FLIF encoder/decoder libraries" ON)
 
+set(SOVERSION 0)
 # find SDL2
 
 find_package(PkgConfig QUIET)
@@ -37,7 +42,9 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(SDL2
                                   REQUIRED_VARS SDL2_INCLUDE_DIR SDL2_LIBRARY SDL2MAIN_LIBRARY)
 
-# /find SDL2
+if(PKG_CONFIG_FOUND)
+pkg_check_modules(GDK gdk-pixbuf-2.0 )
+endif(PKG_CONFIG_FOUND)
 set(FLIF_SRC_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 set(COMMON_SOURCES
@@ -59,14 +66,41 @@ set(COMMON_SOURCES
     ${FLIF_SRC_DIR}/../extern/lodepng.cpp
 )
 
+set(FLIF_DEC_FILES
+  ${FLIF_SRC_DIR}/library/flif_dec.h 
+  ${FLIF_SRC_DIR}/library/flif-interface-private_dec.hpp
+  ${FLIF_SRC_DIR}/library/flif-interface_dec.cpp)
+
+set(FLIF_DEC_HEADERS
+    ${FLIF_SRC_DIR}/library/flif_common.h
+    ${FLIF_SRC_DIR}/library/flif_dec.h
+)
+set(FLIF_ENC_FILES
+  ${FLIF_SRC_DIR}/flif-enc.cpp
+  ${FLIF_SRC_DIR}/library/flif-interface.cpp
+)
+set(FLIF_ENC_HEADERS
+    ${FLIF_SRC_DIR}/library/flif.h
+    ${FLIF_SRC_DIR}/library/flif_common.h
+    ${FLIF_SRC_DIR}/library/flif_dec.h
+    ${FLIF_SRC_DIR}/library/flif_enc.h
+)
+
 if(WIN32)
     set(STATIC_LINKED_LIBS ${ZLIB_LIBRARY})
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+    if(WIN32)
+#This is neeeded to prevent warnings such as:
+#mingw The ABI for passing parameters with 16-byte alignment has changed in GCC 4.6
+#if you compile for i686.
+#but the downside is that the compiled binaries might not work with some old CPU's.
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+    endif(WIN32)
     set(CMAKE_CXX_FLAGS_DEBUG "-ggdb3")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ftree-vectorize")
 endif()
 
 if(USE_ASAN)
@@ -89,49 +123,207 @@ endif()
 add_executable(flif_exe ${COMMON_SOURCES} ${WINDOWS_EXE_SOURCE} ${FLIF_SRC_DIR}/flif-enc.cpp ${FLIF_SRC_DIR}/flif.cpp)
 target_link_libraries(flif_exe ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
 set_target_properties(flif_exe PROPERTIES OUTPUT_NAME flif)
+add_executable(dflif_exe ${COMMON_SOURCES} ${WINDOWS_EXE_SOURCE} ${FLIF_SRC_DIR}/flif-enc.cpp ${FLIF_SRC_DIR}/flif.cpp)
+target_compile_definitions(dflif_exe PRIVATE DECODER_ONLY)
+target_link_libraries(dflif_exe ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
+set_target_properties(dflif_exe PROPERTIES OUTPUT_NAME dflif)
 
 if(WIN32)
     target_include_directories(flif_exe PRIVATE ${FLIF_SRC_DIR}/../build/MSVC/getopt)
     target_compile_definitions(flif_exe PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} STATIC_GETOPT ) # prevents dllexporting symbols for getopt
+    target_include_directories(dflif_exe PRIVATE ${FLIF_SRC_DIR}/../build/MSVC/getopt)
+    target_compile_definitions(dflif_exe PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} STATIC_GETOPT ) # prevents dllexporting symbols for getopt
 endif()
 
 # library
+if(BUILD_SHARED_LIBS)
+    add_library(flif_lib SHARED ${COMMON_SOURCES} ${FLIF_ENC_FILES})
+    add_library(flif_lib_dec SHARED ${COMMON_SOURCES} ${FLIF_DEC_FILES} ${FLIF_DEC_HEADERS})
+#${FLIF_SRC_DIR}/library/flif-interface_dec.cpp)
 
-add_library(flif_lib SHARED ${COMMON_SOURCES} ${FLIF_SRC_DIR}/flif-enc.cpp ${FLIF_SRC_DIR}/library/flif-interface.cpp)
-add_library(flif_lib_dec SHARED ${COMMON_SOURCES} ${FLIF_SRC_DIR}/library/flif-interface_dec.cpp)
+    target_link_libraries(flif_lib ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
+    target_link_libraries(flif_lib_dec ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
 
-target_link_libraries(flif_lib ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
-target_link_libraries(flif_lib_dec ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
+    set_target_properties(flif_lib PROPERTIES OUTPUT_NAME flif)
+    set_target_properties(flif_lib_dec PROPERTIES OUTPUT_NAME flif_dec)
+  
+    set_target_properties(flif_lib PROPERTIES PUBLIC_HEADER "${FLIF_ENC_HEADERS}" SOVERSION ${SOVERSION})   
+    set_target_properties(flif_lib_dec PROPERTIES PUBLIC_HEADER "${FLIF_DEC_HEADERS}" SOVERSION ${SOVERSION})
 
-set_target_properties(flif_lib PROPERTIES OUTPUT_NAME flif)
-set_target_properties(flif_lib_dec PROPERTIES OUTPUT_NAME flif_dec)
+    target_compile_definitions(flif_lib PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} FLIF_BUILD_DLL )
+    target_compile_definitions(flif_lib_dec PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} FLIF_BUILD_DLL DECODER_ONLY )
 
-target_compile_definitions(flif_lib PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} FLIF_BUILD_DLL )
-target_compile_definitions(flif_lib_dec PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} FLIF_BUILD_DLL DECODER_ONLY )
+    target_include_directories(flif_lib PRIVATE ${FLIF_SRC_DIR}/../extern)
+    target_include_directories(flif_lib_dec PRIVATE ${FLIF_SRC_DIR}/../extern)
+
+    target_link_libraries(flif_exe flif_lib)
+    target_link_libraries(dflif_exe flif_lib_dec)
+    install(TARGETS flif_lib flif_lib_dec
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+      PUBLIC_HEADER DESTINATION include)
+endif(BUILD_SHARED_LIBS)
 
 target_include_directories(flif_exe PRIVATE ${FLIF_SRC_DIR}/../extern)
-target_include_directories(flif_lib PRIVATE ${FLIF_SRC_DIR}/../extern)
-target_include_directories(flif_lib_dec PRIVATE ${FLIF_SRC_DIR}/../extern)
+target_include_directories(dflif_exe PRIVATE ${FLIF_SRC_DIR}/../extern)
+install(TARGETS flif_exe dflif_exe
+    RUNTIME DESTINATION bin)
+install(FILES ${FLIF_SRC_DIR}/../tools/gif2flif 
+   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_READ DESTINATION bin)
+install(FILES ${FLIF_SRC_DIR}/../tools/apng2flif 
+   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_READ DESTINATION bin)
+install(FILES ${FLIF_SRC_DIR}/../doc/flif.1
+   DESTINATION ${CMAKE_INSTALL_FULL_MANDIR}/man1)
+
+
+if(BUILD_STATIC_LIBS)
+    add_library(flif_lib_static STATIC ${COMMON_SOURCES} ${FLIF_ENC_FILES})
+    add_library(flif_lib_dec_static STATIC ${COMMON_SOURCES} ${FLIF_DEC_FILES})
+
+    target_link_libraries(flif_lib_static ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
+    target_link_libraries(flif_lib_dec_static ${PNG_LIBRARY} ${STATIC_LINKED_LIBS})
+
+    set_target_properties(flif_lib_static PROPERTIES OUTPUT_NAME flif)
+    set_target_properties(flif_lib_dec_static PROPERTIES OUTPUT_NAME flif_dec)
+
+    set_target_properties(flif_lib_static PROPERTIES PUBLIC_HEADER "${FLIF_ENC_HEADERS}" SOVERSION ${SOVERSION})   
+    set_target_properties(flif_lib_dec_static PROPERTIES PUBLIC_HEADER "${FLIF_DEC_HEADERS}" SOVERSION ${SOVERSION})
+
+    target_compile_definitions(flif_lib_static PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS})
+    target_compile_definitions(flif_lib_dec_static PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS} DECODER_ONLY )
+
+    target_include_directories(flif_lib_static PRIVATE ${FLIF_SRC_DIR}/../extern)
+    target_include_directories(flif_lib_dec_static PRIVATE ${FLIF_SRC_DIR}/../extern)
+
+    install(TARGETS flif_lib_static flif_lib_dec_static
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+      PUBLIC_HEADER DESTINATION include)
+
+    if (NOT(BUILD_SHARED_LIBS))
+       target_link_libraries(flif_exe flif_lib_static)
+       target_link_libraries(dflif_exe flif_lib_dec_static)
+    endif(NOT(BUILD_SHARED_LIBS))
+endif(BUILD_STATIC_LIBS)
+
+# gdk-pixbuf loader, enabling FLIF-viewing in pixbuf applications like Eye of Gnome
+if(GDK_FOUND AND (BUILD_SHARED_LIBS OR BUILD_STATIC_LIBS))
+## The loader is LGPLed so there's no reason to use libflif_dec here
+## -Werror=implicit-function-declaration is useful here to check for preprocessor dependency errors
+#libpixbufloader-flif$(LIBEXT): libflif$(LIBEXT) flif-pixbuf-loader.c
+#	$(CC) -shared $(CFLAGS) -Ilibrary/ -fPIC -Wall -Werror=implicit-function-declaration $(shell pkg-config --cflags gdk-pixbuf-2.0) -o libpixbufloader-flif$(LIBEXT) flif-pixbuf-loader.c $(LDFLAGS) $(shell pkg-config --libs gdk-pixbuf-2.0) -L. -lflif
+    add_library(pixbufloader-flif SHARED flif-pixbuf-loader.c)
+    target_include_directories(pixbufloader-flif PRIVATE ${FLIF_SRC_DIR}/library ${GDK_INCLUDE_DIRS})
+    target_compile_options(pixbufloader-flif PRIVATE ${GDK_CFLAGS})
+    target_compile_definitions(pixbufloader-flif PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS})
+    target_link_libraries(pixbufloader-flif ${GDK_LIBRARIES})
+    set_target_properties(pixbufloader-flif PROPERTIES OUTPUT_NAME pixbufloader-flif)
+
+    add_library(pixbufloader-flif-static STATIC flif-pixbuf-loader.c)
+    target_include_directories(pixbufloader-flif-static PRIVATE ${FLIF_SRC_DIR}/library ${GDK_INCLUDE_DIRS})
+    target_compile_options(pixbufloader-flif-static PRIVATE ${GDK_CFLAGS})
+    target_compile_definitions(pixbufloader-flif-static PRIVATE ${DEFINITIONS_FOR_ALL_TARGETS})
+    target_link_libraries(pixbufloader-flif-static ${GDK_LIBRARIES})
+    set_target_properties(pixbufloader-flif-static PROPERTIES OUTPUT_NAME pixbufloader-flif)
+    if (BUILD_SHARED_LIBS)
+       target_link_libraries(pixbufloader-flif flif_lib)
+       target_link_libraries(pixbufloader-flif-static flif_lib) 
+    else()
+       target_link_libraries(pixbufloader-flif flif_lib_static)
+       target_link_libraries(pixbufloader-flif-static flif_lib_static)
+    endif(BUILD_SHARED_LIBS)
+#We have to be sure that the "-dont-define-prefix", otherwise, on mingw-w64, a complete path
+#is given with pkg-config and that's not desirable for some packaging systems.
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=gdk_pixbuf_moduledir --dont-define-prefix gdk-pixbuf-2.0
+       OUTPUT_VARIABLE GDK_MODULES_DIR ERROR_VARIABLE GDK_RES_ERROR RESULT_VARIABLE RES_VAR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (("${RES_VAR}" STREQUAL "") OR ("${RES_VAR}" STREQUAL "0"))
+           message(STATUS "gdk-pixbuf-2.0 module dir ${GDK_MODULES_DIR}")      
+    else()
+           message(FATAL_ERROR "Error: ${RES_VAR}")
+    endif(("${RES_VAR}" STREQUAL "") OR ("${RES_VAR}" STREQUAL "0"))
+    if ("${GDK_RES_ERROR}" STREQUAL "")
+    install(TARGETS pixbufloader-flif pixbufloader-flif-static 
+      RUNTIME DESTINATION ${GDK_MODULES_DIR}
+      LIBRARY DESTINATION ${GDK_MODULES_DIR}
+      ARCHIVE DESTINATION ${GDK_MODULES_DIR}) 
+    else()
+      message(FATAL_ERROR "Error: ${GDK_RES_ERROR}")
+    endif("${GDK_RES_ERROR}" STREQUAL "")
+#You would want to do this on a user's system.
+#
+#    gdk-pixbuf-query-loaders --update-cache
+#
+# We don't do that here because I see this CMakeLists.txt file for software
+#packagers.
+endif(GDK_FOUND AND (BUILD_SHARED_LIBS OR BUILD_STATIC_LIBS))
+
+# mime-info
+find_program(SHARED_MIME_PROG "update-mime-database")
+if (SHARED_MIME_PROG)
+    install(FILES ${FLIF_SRC_DIR}/flif-mime.xml
+      DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/mime/packages)
+#you would want to do something like:
+#
+#    execute_process(COMMAND #{SHARED_MIME_PROG} ${CMAKE_INSTALL_PREFIX}/share/mime    )
+#
+#but that type of thing should be done on the user's sytem, not on a build system
+#It does require the "shared-mime-info" package
+endif(SHARED_MIME_PROG)
+
+# Magic data file
+#
+# For deployment, you want to do  something like this on the end-user's system
+#
+#if ! grep -q FLIF /etc/magic; then cat ${CMAKE_INSTALL_FULL_DATAROOTDIR}/doc/flif.magic >> /etc/magic; fi
+#
+install(FILES ${FLIF_SRC_DIR}/../doc/flif.magic
+   DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/FLIF)
 
 # viewflif
 
-if(${SDL2_FOUND})
-    add_executable(viewflif ${FLIF_SRC_DIR}/viewflif.c)
+if(${SDL2_FOUND} AND ${BUILD_SHARED_LIBS})
+    if(WIN32)
+      add_executable(viewflif WIN32 ${FLIF_SRC_DIR}/viewflif.c)
+    else(WIN32)
+      add_executable(viewflif ${FLIF_SRC_DIR}/viewflif.c)
+    endif(WIN32)
     set_source_files_properties(${FLIF_SRC_DIR}/viewflif.c PROPERTIES LANGUAGE CXX)
-    target_link_libraries(viewflif flif_lib_dec ${SDL2_LIBRARY} ${SDL2MAIN_LIBRARY})
+    if ("${PKG_SDL2_STATIC_LIBRARIES}" STREQUAL "")
+      target_link_libraries(viewflif flif_lib_dec ${SDL2_LIBRARY} ${SDL2MAIN_LIBRARY})
+    else("${PKG_SDL2_STATIC_LIBRARIES}" STREQUAL "")
+      target_link_libraries(viewflif flif_lib_dec ${PKG_SDL2_STATIC_LIBRARIES})
+    endif("${PKG_SDL2_STATIC_LIBRARIES}" STREQUAL "")
     target_include_directories(viewflif PRIVATE ${FLIF_SRC_DIR}/library ${SDL2_INCLUDE_DIR})
     target_compile_definitions(viewflif PRIVATE FLIF_USE_DLL)
-endif()
+    install(TARGETS viewflif
+      RUNTIME DESTINATION bin)
+endif(${SDL2_FOUND} AND ${BUILD_SHARED_LIBS})
 
 # test
 
+if(BUILD_SHARED_LIBS)
 add_executable(libtest ${FLIF_SRC_DIR}/../tools/test.c)
 target_link_libraries(libtest flif_lib)
 target_include_directories(libtest PRIVATE ${FLIF_SRC_DIR}/library)
 target_compile_definitions(libtest PRIVATE FLIF_USE_DLL)
+endif(BUILD_SHARED_LIBS)
+
+if(BUILD_STATIC_LIBS)
+add_executable(libtest_static ${FLIF_SRC_DIR}/../tools/test.c)
+target_link_libraries(libtest_static flif_lib)
+target_include_directories(libtest_static PRIVATE ${FLIF_SRC_DIR}/library)
+endif(BUILD_STATIC_LIBS)
+
+# license stuff
+install(FILES "${FLIF_SRC_DIR}/../LICENSE" "${FLIF_SRC_DIR}/../LICENSE_Apache2" "${FLIF_SRC_DIR}/../LICENSE_GPL" "${FLIF_SRC_DIR}/../LICENSE_LGPL" "${FLIF_SRC_DIR}/../FLIF-CLA-template.txt"
+   DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/FLIF")
 
 enable_testing()
 add_test(NAME libtest COMMAND libtest dummy.flif)
+add_test(NAME libtest_static COMMAND libtest_static dummy.flif)
+
 if(UNIX)
     add_test(NAME roundtrip1 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/test-roundtrip.sh ${CMAKE_CURRENT_SOURCE_DIR}/../tools/2_webp_ll.png 2_webp_ll.flif decoded_2_webp_ll.png)
     add_test(NAME roundtrip2 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/test-roundtrip.sh ${CMAKE_CURRENT_SOURCE_DIR}/../tools/kodim01.png kodim01.flif decoded_kodim01.png)

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,18 @@
 #define USE_SIMD 1
 #endif
 
+/**************************/
+/* FIX COMPILER WARNINGS  */
+/**************************/
+
+#ifdef UNUSED
+#elif defined(__GNUC__) 
+# define UNUSED(x) UNUSED_ ## x __attribute__((unused)) 
+#elif defined(__LCLINT__) 
+# define UNUSED(x) /*@unused@*/ x 
+#else 
+# define UNUSED(x) x 
+#endif
 
 /*************************************************/
 /* OPTIONS TO CHANGE DEFAULT ENCODING PARAMETERS */

--- a/src/config.h
+++ b/src/config.h
@@ -47,13 +47,13 @@
 /* FIX COMPILER WARNINGS  */
 /**************************/
 
-#ifdef UNUSED
-#elif defined(__GNUC__) 
-# define UNUSED(x) UNUSED_ ## x __attribute__((unused)) 
+#ifdef FLIF_UNUSED
+#elif defined(__GNUC__) || defined(__clang__)
+# define FLIF_UNUSED(x) x __attribute__((unused)) 
 #elif defined(__LCLINT__) 
-# define UNUSED(x) /*@unused@*/ x 
+# define FLIF_UNUSED(x) /*@unused@*/ x 
 #else 
-# define UNUSED(x) x 
+# define FLIF_UNUSED(x) x 
 #endif
 
 /*************************************************/

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -111,7 +111,7 @@ public:
         else
             return buf;
     }
-    int fputc(int c) {
+    int fputc(int UNUSED(c)) {
       // cannot write on const memory
       return EOS;
     }

--- a/src/fileio.hpp
+++ b/src/fileio.hpp
@@ -111,7 +111,7 @@ public:
         else
             return buf;
     }
-    int fputc(int UNUSED(c)) {
+    int fputc(int FLIF_UNUSED(c)) {
       // cannot write on const memory
       return EOS;
     }

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -167,7 +167,7 @@ void downsample(const int width, const int height, int target_w, int target_h, I
 
 
 template<typename IO, typename Rac, typename Coder>
-bool flif_decode_scanlines_inner(IO &io, Rac &rac, std::vector<Coder> &coders, Images &images, const ColorRanges *ranges, flif_options &options,
+bool flif_decode_scanlines_inner(IO &io, Rac &UNUSED(rac), std::vector<Coder> &coders, Images &images, const ColorRanges *ranges, flif_options &options,
                                  std::vector<Transform<IO>*> &transforms, callback_t callback, void *user_data, Images &partial_images) {
     const int nump = images[0].numPlanes();
     const bool alphazero = images[0].alpha_zero_special;
@@ -609,8 +609,8 @@ struct vertical_plane_decoder: public PlaneVisitor {
 };
 
 template<typename IO, typename Rac, typename Coder, typename alpha_t, typename ranges_t>
-bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, Rac &rac, std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
-                             const int beginZL, const int endZL, int quality, int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
+bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, Rac &UNUSED(rac), std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
+                             const int beginZL, const int endZL, int UNUSED(quality), int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
     const int nump = images[0].numPlanes();
     const bool alphazero = images[0].alpha_zero_special;
     const bool FRA = (nump == 5);
@@ -640,8 +640,8 @@ bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, Rac &rac, std::vect
           return true;
 }
 template<typename IO, typename Rac, typename Coder, typename alpha_t, typename ranges_t>
-bool flif_decode_FLIF2_inner_vertical(const int p, IO& io, Rac &rac, std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
-                             const int beginZL, const int endZL, int quality, int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
+bool flif_decode_FLIF2_inner_vertical(const int p, IO& io, Rac &UNUSED(rac), std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
+                             const int beginZL, const int endZL, int UNUSED(quality), int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
     const int nump = images[0].numPlanes();
     const bool alphazero = images[0].alpha_zero_special;
     const bool FRA = (nump == 5);
@@ -855,7 +855,7 @@ bool flif_decode_FLIF2_pass(IO &io, Rac &rac, Images &images, const ColorRanges 
 
 
 
-template<typename IO, typename BitChance, typename Rac> bool flif_decode_tree(IO& io, Rac &rac, const ColorRanges *ranges, std::vector<Tree> &forest, const flifEncoding encoding)
+template<typename IO, typename BitChance, typename Rac> bool flif_decode_tree(IO& UNUSED(io), Rac &rac, const ColorRanges *ranges, std::vector<Tree> &forest, const flifEncoding encoding)
 {
     try {
       for (int p = 0; p < ranges->numPlanes(); p++) {

--- a/src/flif-dec.cpp
+++ b/src/flif-dec.cpp
@@ -167,7 +167,7 @@ void downsample(const int width, const int height, int target_w, int target_h, I
 
 
 template<typename IO, typename Rac, typename Coder>
-bool flif_decode_scanlines_inner(IO &io, Rac &UNUSED(rac), std::vector<Coder> &coders, Images &images, const ColorRanges *ranges, flif_options &options,
+bool flif_decode_scanlines_inner(IO &io, FLIF_UNUSED(Rac &rac), std::vector<Coder> &coders, Images &images, const ColorRanges *ranges, flif_options &options,
                                  std::vector<Transform<IO>*> &transforms, callback_t callback, void *user_data, Images &partial_images) {
     const int nump = images[0].numPlanes();
     const bool alphazero = images[0].alpha_zero_special;
@@ -609,8 +609,8 @@ struct vertical_plane_decoder: public PlaneVisitor {
 };
 
 template<typename IO, typename Rac, typename Coder, typename alpha_t, typename ranges_t>
-bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, Rac &UNUSED(rac), std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
-                             const int beginZL, const int endZL, int UNUSED(quality), int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
+bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, FLIF_UNUSED(Rac &rac), std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
+                             const int beginZL, const int endZL, FLIF_UNUSED(int quality), int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
     const int nump = images[0].numPlanes();
     const bool alphazero = images[0].alpha_zero_special;
     const bool FRA = (nump == 5);
@@ -640,8 +640,8 @@ bool flif_decode_FLIF2_inner_horizontal(const int p, IO& io, Rac &UNUSED(rac), s
           return true;
 }
 template<typename IO, typename Rac, typename Coder, typename alpha_t, typename ranges_t>
-bool flif_decode_FLIF2_inner_vertical(const int p, IO& io, Rac &UNUSED(rac), std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
-                             const int beginZL, const int endZL, int UNUSED(quality), int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
+bool flif_decode_FLIF2_inner_vertical(const int p, IO& io, FLIF_UNUSED(Rac &rac), std::vector<Coder> &coders, Images &images, const ranges_t *ranges,
+                             const int beginZL, const int endZL, FLIF_UNUSED(int quality), int scale, const int i, const int z, const int predictor, std::vector<int>& zoomlevels, std::vector<Transform<IO>*> &transforms, const int invisible_predictor) {
     const int nump = images[0].numPlanes();
     const bool alphazero = images[0].alpha_zero_special;
     const bool FRA = (nump == 5);
@@ -855,7 +855,7 @@ bool flif_decode_FLIF2_pass(IO &io, Rac &rac, Images &images, const ColorRanges 
 
 
 
-template<typename IO, typename BitChance, typename Rac> bool flif_decode_tree(IO& UNUSED(io), Rac &rac, const ColorRanges *ranges, std::vector<Tree> &forest, const flifEncoding encoding)
+template<typename IO, typename BitChance, typename Rac> bool flif_decode_tree(FLIF_UNUSED(IO& io), Rac &rac, const ColorRanges *ranges, std::vector<Tree> &forest, const flifEncoding encoding)
 {
     try {
       for (int p = 0; p < ranges->numPlanes(); p++) {

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -50,7 +50,7 @@ template<typename RAC> void static write_name(RAC& rac, std::string desc) {
 // alphazero = false: image either has no alpha plane, or A=0 has no special meaning
 // FRA = true: image has FRA plane (animation with lookback)
 template<typename IO, typename Rac, typename Coder>
-void flif_encode_scanlines_inner(IO& io, Rac& UNUSED(rac), std::vector<Coder> &coders, const Images &images, const ColorRanges *ranges) {
+void flif_encode_scanlines_inner(IO& io, FLIF_UNUSED(Rac& rac), std::vector<Coder> &coders, const Images &images, const ColorRanges *ranges) {
     const std::vector<ColorVal> greys = computeGreys(ranges);
     ColorVal min,max;
     long fs = io.ftell();
@@ -666,7 +666,7 @@ void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int 
     }
 }
 
-template<typename IO, typename BitChance, typename Rac> void flif_encode_tree(IO& UNUSED(io), Rac &rac, const ColorRanges *ranges, const std::vector<Tree> &forest, const flifEncoding encoding)
+template<typename IO, typename BitChance, typename Rac> void flif_encode_tree(FLIF_UNUSED(IO& io), Rac &rac, const ColorRanges *ranges, const std::vector<Tree> &forest, const flifEncoding encoding)
 {
     for (int p = 0; p < ranges->numPlanes(); p++) {
         Ranges propRanges;

--- a/src/flif-enc.cpp
+++ b/src/flif-enc.cpp
@@ -50,7 +50,7 @@ template<typename RAC> void static write_name(RAC& rac, std::string desc) {
 // alphazero = false: image either has no alpha plane, or A=0 has no special meaning
 // FRA = true: image has FRA plane (animation with lookback)
 template<typename IO, typename Rac, typename Coder>
-void flif_encode_scanlines_inner(IO& io, Rac& rac, std::vector<Coder> &coders, const Images &images, const ColorRanges *ranges) {
+void flif_encode_scanlines_inner(IO& io, Rac& UNUSED(rac), std::vector<Coder> &coders, const Images &images, const ColorRanges *ranges) {
     const std::vector<ColorVal> greys = computeGreys(ranges);
     ColorVal min,max;
     long fs = io.ftell();
@@ -666,7 +666,7 @@ void flif_make_lossy_interlaced(Images &images, const ColorRanges * ranges, int 
     }
 }
 
-template<typename IO, typename BitChance, typename Rac> void flif_encode_tree(IO& io, Rac &rac, const ColorRanges *ranges, const std::vector<Tree> &forest, const flifEncoding encoding)
+template<typename IO, typename BitChance, typename Rac> void flif_encode_tree(IO& UNUSED(io), Rac &rac, const ColorRanges *ranges, const std::vector<Tree> &forest, const flifEncoding encoding)
 {
     for (int p = 0; p < ranges->numPlanes(); p++) {
         Ranges propRanges;

--- a/src/flif-pixbuf-loader.c
+++ b/src/flif-pixbuf-loader.c
@@ -134,7 +134,7 @@ static GdkPixbuf *gdk_pixbuf__flif_image_load (FILE *f, GError **error) {
     gint32 rowstride = gdk_pixbuf_get_rowstride(pixbuf);
     guchar *pixels = gdk_pixbuf_get_pixels(pixbuf);
     guchar *rowpointer = pixels;
-    for (uint32_t row = 0; row < h; row++) {
+    for (uint32_t row = 0; row < (uint32_t)h; row++) {
         flif_image_read_row_RGBA8(image, row, rowpointer, w * 4);
         rowpointer += rowstride;
     }
@@ -263,7 +263,7 @@ static gboolean gdk_pixbuf__flif_image_load_increment (gpointer user_context, co
             gint scaled_h = context->h;
 
             (* context->size_func) (&scaled_w, &scaled_h, context->user_data);
-            if (scaled_w != context->w || scaled_h != context->h) {
+            if ((guint)scaled_w != context->w || (guint)scaled_h != context->h) {
                 context->w = scaled_w;
                 context->h = scaled_h;
             }

--- a/src/flif.cpp
+++ b/src/flif.cpp
@@ -268,7 +268,7 @@ bool encode_load_input_images(int argc, char **argv, Images &images, flif_option
     return false;
 }
 
-bool encode_flif(int UNUSED(argc), char **argv, Images &images, flif_options &options) {
+bool encode_flif(FLIF_UNUSED(int argc), char **argv, Images &images, flif_options &options) {
     bool flat=true;
     unsigned int framenb=0;
     for (Image& i : images) { i.frame_delay = options.frame_delay[framenb]; if (framenb+1 < options.frame_delay.size()) framenb++; }

--- a/src/flif.cpp
+++ b/src/flif.cpp
@@ -268,7 +268,7 @@ bool encode_load_input_images(int argc, char **argv, Images &images, flif_option
     return false;
 }
 
-bool encode_flif(int argc, char **argv, Images &images, flif_options &options) {
+bool encode_flif(int UNUSED(argc), char **argv, Images &images, flif_options &options) {
     bool flat=true;
     unsigned int framenb=0;
     for (Image& i : images) { i.frame_delay = options.frame_delay[framenb]; if (framenb+1 < options.frame_delay.size()) framenb++; }

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -362,34 +362,34 @@ class ConstantPlane final : public GeneralPlane {
     ColorVal color;
 public:
     explicit ConstantPlane(ColorVal c) : color(c) {}
-    void set(const size_t r, const size_t c, const ColorVal x) override {
+    void set(const size_t UNUSED(r), const size_t UNUSED(c), const ColorVal x) override {
         assert(x == color);
     }
-    ColorVal get(const size_t r, const size_t c) const override {
+    ColorVal get(const size_t UNUSED(r), const size_t UNUSED(c)) const override {
         return color;
     }
 
-    void prepare_zoomlevel(const int z) const override {}
-    ColorVal get_fast(size_t r, size_t c) const override { return color; }
-    void set_fast(size_t r, size_t c, ColorVal x) override { assert(x == color); }
+    void prepare_zoomlevel(const int UNUSED(z)) const override {}
+    ColorVal get_fast(size_t UNUSED(r), size_t UNUSED(c)) const override { return color; }
+    void set_fast(size_t UNUSED(r), size_t UNUSED(c), ColorVal x) override { assert(x == color); }
 
 #ifdef USE_SIMD
-    FourColorVals get4(const size_t pos) const ATTRIBUTE_HOT {
+    FourColorVals get4(const size_t UNUSED(pos)) const ATTRIBUTE_HOT {
         FourColorVals x {color,color,color,color};
         return x;
     }
-    void VCALL set4(const size_t pos, const FourColorVals x) override {
+    void VCALL set4(const size_t UNUSED(pos), const FourColorVals x) override {
         assert(x[0] == color);
         assert(x[1] == color);
         assert(x[2] == color);
         assert(x[3] == color);
     }
-    EightColorVals get8(const size_t pos) const ATTRIBUTE_HOT {
+    EightColorVals get8(const size_t UNUSED(pos)) const ATTRIBUTE_HOT {
         int16_t c = color;
         EightColorVals x {c,c,c,c,c,c,c,c};
         return x;
     }
-    void VCALL set8(const size_t pos, const EightColorVals x) override {
+    void VCALL set8(const size_t UNUSED(pos), const EightColorVals x) override {
         assert(x[0] == color);
         assert(x[1] == color);
         assert(x[2] == color);
@@ -402,15 +402,15 @@ public:
 #endif
     bool is_constant() const override { return true; }
 
-    void set(const int z, const size_t r, const size_t c, const ColorVal x) override {
+    void set(const int UNUSED(z), const size_t UNUSED(r), const size_t UNUSED(c), const ColorVal x) override {
         assert(x == color);
     }
-    ColorVal get(const int z, const size_t r, const size_t c) const override {
+    ColorVal get(const int UNUSED(z), const size_t UNUSED(r), const size_t UNUSED(c)) const override {
         return color;
     }
 
 
-    void accept_visitor(PlaneVisitor &v) override {
+    void accept_visitor(PlaneVisitor &UNUSED(v)) override {
 //        v.visit(*this);
         assert(false); // there should never be a need to visit a constant plane
     }
@@ -861,9 +861,11 @@ public:
         switch(num) {
             case 1:
               make_constant_plane(1,0);
+              // fall through
             case 2:
               make_constant_plane(2,0);
               num=3;
+              // fall through
             default:
               assert(num>=3);
         }
@@ -874,6 +876,7 @@ public:
             case 3:
               make_constant_plane(3,1);
               num=4;
+              // fall through
             default:
               assert(num>=4);
         }

--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -184,7 +184,7 @@ public:
     virtual void set(const int z, const size_t r, const size_t c, const ColorVal x) =0;
     virtual ColorVal get(const int z, const size_t r, const size_t c) const =0;
     virtual void normalize_scale() {}
-    virtual void accept_visitor(PlaneVisitor &v) =0;
+    virtual void accept_visitor(FLIF_UNUSED(PlaneVisitor &v)) =0;
     virtual uint32_t compute_crc32(uint32_t previous_crc32) =0;
     // access pixel by zoomlevel coordinate
     static size_t zoom_rowpixelsize(int zoomlevel) {
@@ -333,7 +333,7 @@ public:
 
     int bytes_per_pixel() const override { return sizeof(pixel_t); }
 
-    void accept_visitor(PlaneVisitor &v) override {
+    void accept_visitor(FLIF_UNUSED(PlaneVisitor &v)) override {
         v.visit(*this);
     }
     uint32_t compute_crc32(uint32_t previous_crc32) override {
@@ -362,34 +362,34 @@ class ConstantPlane final : public GeneralPlane {
     ColorVal color;
 public:
     explicit ConstantPlane(ColorVal c) : color(c) {}
-    void set(const size_t UNUSED(r), const size_t UNUSED(c), const ColorVal x) override {
+    void set(FLIF_UNUSED(const size_t r), FLIF_UNUSED(const size_t c), FLIF_UNUSED(const ColorVal x)) override {
         assert(x == color);
     }
-    ColorVal get(const size_t UNUSED(r), const size_t UNUSED(c)) const override {
+    ColorVal get(FLIF_UNUSED(const size_t r), FLIF_UNUSED(const size_t c)) const override {
         return color;
     }
 
-    void prepare_zoomlevel(const int UNUSED(z)) const override {}
-    ColorVal get_fast(size_t UNUSED(r), size_t UNUSED(c)) const override { return color; }
-    void set_fast(size_t UNUSED(r), size_t UNUSED(c), ColorVal x) override { assert(x == color); }
+    void prepare_zoomlevel(FLIF_UNUSED(const int z)) const override {}
+    ColorVal get_fast(FLIF_UNUSED(size_t r), FLIF_UNUSED(size_t c)) const override { return color; }
+    void set_fast(FLIF_UNUSED(size_t r), FLIF_UNUSED(size_t c), FLIF_UNUSED(ColorVal x)) override { assert(x == color); }
 
 #ifdef USE_SIMD
-    FourColorVals get4(const size_t UNUSED(pos)) const ATTRIBUTE_HOT {
+    FourColorVals get4(FLIF_UNUSED(const size_t pos)) const ATTRIBUTE_HOT {
         FourColorVals x {color,color,color,color};
         return x;
     }
-    void VCALL set4(const size_t UNUSED(pos), const FourColorVals x) override {
+    void VCALL set4(FLIF_UNUSED(const size_t pos), const FourColorVals x) override {
         assert(x[0] == color);
         assert(x[1] == color);
         assert(x[2] == color);
         assert(x[3] == color);
     }
-    EightColorVals get8(const size_t UNUSED(pos)) const ATTRIBUTE_HOT {
+    EightColorVals get8(FLIF_UNUSED(const size_t pos)) const ATTRIBUTE_HOT {
         int16_t c = color;
         EightColorVals x {c,c,c,c,c,c,c,c};
         return x;
     }
-    void VCALL set8(const size_t UNUSED(pos), const EightColorVals x) override {
+    void VCALL set8(FLIF_UNUSED(const size_t pos), const EightColorVals x) override {
         assert(x[0] == color);
         assert(x[1] == color);
         assert(x[2] == color);
@@ -402,15 +402,15 @@ public:
 #endif
     bool is_constant() const override { return true; }
 
-    void set(const int UNUSED(z), const size_t UNUSED(r), const size_t UNUSED(c), const ColorVal x) override {
+    void set(FLIF_UNUSED(const int z), FLIF_UNUSED(const size_t r), FLIF_UNUSED(const size_t c), FLIF_UNUSED(const ColorVal x)) override {
         assert(x == color);
     }
-    ColorVal get(const int UNUSED(z), const size_t UNUSED(r), const size_t UNUSED(c)) const override {
+    ColorVal get(FLIF_UNUSED(const int z), FLIF_UNUSED(const size_t r), FLIF_UNUSED(const size_t c)) const override {
         return color;
     }
 
 
-    void accept_visitor(PlaneVisitor &UNUSED(v)) override {
+    void accept_visitor(FLIF_UNUSED(PlaneVisitor &v)) override {
 //        v.visit(*this);
         assert(false); // there should never be a need to visit a constant plane
     }

--- a/src/library/flif-interface-private_common.hpp
+++ b/src/library/flif-interface-private_common.hpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include "../image/image.hpp"
 #include "../fileio.hpp"
 
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined(__MINGW32__)
  #ifdef FLIF_BUILD_DLL
   #define FLIF_DLLEXPORT __declspec(dllexport)
  #else

--- a/src/library/flif-interface-private_common.hpp
+++ b/src/library/flif-interface-private_common.hpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include "../image/image.hpp"
 #include "../fileio.hpp"
 
-#if defined (_MSC_VER) || defined(__MINGW32__)
+#ifdef _WIN32
  #ifdef FLIF_BUILD_DLL
   #define FLIF_DLLEXPORT __declspec(dllexport)
  #else

--- a/src/library/flif-interface_enc.cpp
+++ b/src/library/flif-interface_enc.cpp
@@ -181,6 +181,11 @@ FLIF_DLLEXPORT void FLIF_API flif_encoder_set_alpha_zero(FLIF_ENCODER* encoder, 
     catch(...) {}
 }
 
+FLIF_DLLIMPORT void FLIF_API flif_encoder_set_alpha_zero_lossless(FLIF_ENCODER* encoder) {
+    flif_encoder_set_alpha_zero(encoder,1); 
+}
+ 
+
 FLIF_DLLEXPORT void FLIF_API flif_encoder_set_crc_check(FLIF_ENCODER* encoder, uint32_t crc_check) {
     encoder->options.crc_check = crc_check;
 }

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define FLIF_API __cdecl
  #ifdef FLIF_BUILD_DLL
   #define FLIF_DLLIMPORT __declspec(dllexport)

--- a/src/library/flif_common.h
+++ b/src/library/flif_common.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include <stdint.h>
 #include <stddef.h>
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#ifdef _WIN32
 #define FLIF_API __cdecl
  #ifdef FLIF_BUILD_DLL
   #define FLIF_DLLIMPORT __declspec(dllexport)

--- a/src/library/flif_enc.h
+++ b/src/library/flif_enc.h
@@ -58,7 +58,8 @@ extern "C" {
     FLIF_DLLIMPORT void FLIF_API flif_encoder_set_split_threshold(FLIF_ENCODER* encoder, int32_t threshold);   // default: 64 (-T)
     // The default is to not store RGB values of fully transparent pixels. If you want to avoid that, you have to change it with this function!
     FLIF_DLLIMPORT void FLIF_API flif_encoder_set_alpha_zero(FLIF_ENCODER* encoder, int32_t lossless);  // 0 = default (RGB undefined when A=0), 1 = keep RGB at A=0 (-K)
-    FLIF_DLLIMPORT void FLIF_API flif_encoder_set_alpha_zero_lossless(FLIF_ENCODER* encoder) { flif_encoder_set_alpha_zero(encoder,1); };
+    //error: dllimport cannot be applied to non-inline function definition
+    FLIF_DLLIMPORT void FLIF_API flif_encoder_set_alpha_zero_lossless(FLIF_ENCODER* encoder);
     FLIF_DLLIMPORT void FLIF_API flif_encoder_set_chance_cutoff(FLIF_ENCODER* encoder, int32_t cutoff); // default: 2  (-X)
     FLIF_DLLIMPORT void FLIF_API flif_encoder_set_chance_alpha(FLIF_ENCODER* encoder, int32_t alpha);   // default: 19 (-Z)
     FLIF_DLLIMPORT void FLIF_API flif_encoder_set_crc_check(FLIF_ENCODER* encoder, uint32_t crc_check); // 0 = no CRC, 1 = add CRC

--- a/src/maniac/compound.hpp
+++ b/src/maniac/compound.hpp
@@ -165,7 +165,7 @@ private:
     }
 
 public:
-    FinalPropertySymbolCoder(RAC& racIn, Ranges &rangeIn, Tree &treeIn, int UNUSED(ignored_split_threshold) = 0, int cut = 4, int alpha = 0xFFFFFFFF / 20) :
+    FinalPropertySymbolCoder(RAC& racIn, Ranges &rangeIn, Tree &treeIn, int FLIF_UNUSED(ignored_split_threshold) = 0, int cut = 4, int alpha = 0xFFFFFFFF / 20) :
         coder(racIn, cut, alpha),
 //        range(rangeIn),
         nb_properties(rangeIn.size()),
@@ -192,7 +192,7 @@ public:
 #ifdef HAS_ENCODER
     void write_int(const Properties &properties, int min, int max, int val);
     void write_int(const Properties &properties, int nbits, int val);
-    static void simplify(int UNUSED(divisor)=CONTEXT_TREE_COUNT_DIV, int UNUSED(min_size)=CONTEXT_TREE_MIN_SUBTREE_SIZE, int UNUSED(plane)=0) {}
+    static void simplify(FLIF_UNUSED(int divisor)=CONTEXT_TREE_COUNT_DIV, FLIF_UNUSED(int min_size)=CONTEXT_TREE_MIN_SUBTREE_SIZE, FLIF_UNUSED(int plane)=0) {}
     static uint64_t compute_total_size() {return 0;}
 #endif
 

--- a/src/maniac/compound.hpp
+++ b/src/maniac/compound.hpp
@@ -165,7 +165,7 @@ private:
     }
 
 public:
-    FinalPropertySymbolCoder(RAC& racIn, Ranges &rangeIn, Tree &treeIn, int ignored_split_threshold = 0, int cut = 4, int alpha = 0xFFFFFFFF / 20) :
+    FinalPropertySymbolCoder(RAC& racIn, Ranges &rangeIn, Tree &treeIn, int UNUSED(ignored_split_threshold) = 0, int cut = 4, int alpha = 0xFFFFFFFF / 20) :
         coder(racIn, cut, alpha),
 //        range(rangeIn),
         nb_properties(rangeIn.size()),
@@ -192,7 +192,7 @@ public:
 #ifdef HAS_ENCODER
     void write_int(const Properties &properties, int min, int max, int val);
     void write_int(const Properties &properties, int nbits, int val);
-    static void simplify(int divisor=CONTEXT_TREE_COUNT_DIV, int min_size=CONTEXT_TREE_MIN_SUBTREE_SIZE, int plane=0) {}
+    static void simplify(int UNUSED(divisor)=CONTEXT_TREE_COUNT_DIV, int UNUSED(min_size)=CONTEXT_TREE_MIN_SUBTREE_SIZE, int UNUSED(plane)=0) {}
     static uint64_t compute_total_size() {return 0;}
 #endif
 

--- a/src/maniac/rac_enc.hpp
+++ b/src/maniac/rac_enc.hpp
@@ -95,7 +95,7 @@ public:
 
 class RacDummy {
 public:
-    static void inline write_12bit_chance(uint16_t UNUSED(b12), bool) { }
+    static void inline write_12bit_chance(FLIF_UNUSED(uint16_t b12), bool) { }
     static void inline write_bit(bool) { }
     static void inline flush() { }
 };

--- a/src/maniac/rac_enc.hpp
+++ b/src/maniac/rac_enc.hpp
@@ -95,7 +95,7 @@ public:
 
 class RacDummy {
 public:
-    static void inline write_12bit_chance(uint16_t b12, bool) { }
+    static void inline write_12bit_chance(uint16_t UNUSED(b12), bool) { }
     static void inline write_bit(bool) { }
     static void inline flush() { }
 };

--- a/src/transform/colorbuckets.hpp
+++ b/src/transform/colorbuckets.hpp
@@ -542,7 +542,7 @@ protected:
         }
     }
 
-    bool process(const ColorRanges *srcRanges, const Images &images) override {
+    bool process(const ColorRanges *UNUSED(srcRanges), const Images &images) override {
             std::vector<ColorVal> pixel(images[0].numPlanes());
             // fill buckets
             for (const Image& image : images)

--- a/src/transform/colorbuckets.hpp
+++ b/src/transform/colorbuckets.hpp
@@ -542,7 +542,7 @@ protected:
         }
     }
 
-    bool process(const ColorRanges *UNUSED(srcRanges), const Images &images) override {
+    bool process(FLIF_UNUSED(const ColorRanges *srcRanges), const Images &images) override {
             std::vector<ColorVal> pixel(images[0].numPlanes());
             // fill buckets
             for (const Image& image : images)

--- a/src/transform/framecombine.hpp
+++ b/src/transform/framecombine.hpp
@@ -154,7 +154,7 @@ protected:
 #endif
 
     void configure(const int setting) override { user_max_lookback=nb_frames=setting; }
-    void invData(Images &images, uint32_t UNUSED(strideCol), uint32_t UNUSED(strideRow)) const override {
+    void invData(Images &images, FLIF_UNUSED(uint32_t strideCol), FLIF_UNUSED(uint32_t strideRow)) const override {
         // most work has to be done on the fly in the decoder, this is just some cleaning up
         for (Image& image : images) image.drop_frame_lookbacks();
         if (was_flat) for (Image& image : images) image.drop_alpha();

--- a/src/transform/framecombine.hpp
+++ b/src/transform/framecombine.hpp
@@ -154,7 +154,7 @@ protected:
 #endif
 
     void configure(const int setting) override { user_max_lookback=nb_frames=setting; }
-    void invData(Images &images, uint32_t strideCol, uint32_t strideRow) const override {
+    void invData(Images &images, uint32_t UNUSED(strideCol), uint32_t UNUSED(strideRow)) const override {
         // most work has to be done on the fly in the decoder, this is just some cleaning up
         for (Image& image : images) image.drop_frame_lookbacks();
         if (was_flat) for (Image& image : images) image.drop_alpha();

--- a/src/transform/palette_C.hpp
+++ b/src/transform/palette_C.hpp
@@ -34,9 +34,9 @@ public:
     bool isStatic() const override { return true; }
     int numPlanes() const override { return ranges->numPlanes(); }
 
-    ColorVal min(int UNUSED(p)) const override { return 0; }
+    ColorVal min(FLIF_UNUSED(int p)) const override { return 0; }
     ColorVal max(int p) const override { return nb_colors[p]; }
-    void minmax(const int p, const prevPlanes &UNUSED(pp), ColorVal &minv, ColorVal &maxv) const override {
+    void minmax(const int p, FLIF_UNUSED(const prevPlanes &pp), ColorVal &minv, ColorVal &maxv) const override {
          minv=0; maxv=nb_colors[p];
     }
 
@@ -55,7 +55,7 @@ public:
         return true;
     }
 
-    const ColorRanges *meta(Images& UNUSED(images), const ColorRanges *srcRanges) override {
+    const ColorRanges *meta(FLIF_UNUSED(Images& images), const ColorRanges *srcRanges) override {
         int nb[4] = {};
         v_printf(4,"[");
         for (int i=0; i<srcRanges->numPlanes(); i++) {
@@ -68,7 +68,7 @@ public:
         return new ColorRangesPaletteC(srcRanges, nb);
     }
 
-    void invData(Images& images, uint32_t UNUSED(strideCol), uint32_t UNUSED(strideRow)) const override {
+    void invData(Images& images, FLIF_UNUSED(uint32_t strideCol), FLIF_UNUSED(uint32_t strideRow)) const override {
         for (Image& image : images) {
 
          const uint32_t scaledRows = image.scaledRows();

--- a/src/transform/palette_C.hpp
+++ b/src/transform/palette_C.hpp
@@ -34,9 +34,9 @@ public:
     bool isStatic() const override { return true; }
     int numPlanes() const override { return ranges->numPlanes(); }
 
-    ColorVal min(int p) const override { return 0; }
+    ColorVal min(int UNUSED(p)) const override { return 0; }
     ColorVal max(int p) const override { return nb_colors[p]; }
-    void minmax(const int p, const prevPlanes &pp, ColorVal &minv, ColorVal &maxv) const override {
+    void minmax(const int p, const prevPlanes &UNUSED(pp), ColorVal &minv, ColorVal &maxv) const override {
          minv=0; maxv=nb_colors[p];
     }
 
@@ -55,7 +55,7 @@ public:
         return true;
     }
 
-    const ColorRanges *meta(Images& images, const ColorRanges *srcRanges) override {
+    const ColorRanges *meta(Images& UNUSED(images), const ColorRanges *srcRanges) override {
         int nb[4] = {};
         v_printf(4,"[");
         for (int i=0; i<srcRanges->numPlanes(); i++) {
@@ -68,7 +68,7 @@ public:
         return new ColorRangesPaletteC(srcRanges, nb);
     }
 
-    void invData(Images& images, uint32_t strideCol, uint32_t strideRow) const override {
+    void invData(Images& images, uint32_t UNUSED(strideCol), uint32_t UNUSED(strideRow)) const override {
         for (Image& image : images) {
 
          const uint32_t scaledRows = image.scaledRows();

--- a/src/transform/transform.hpp
+++ b/src/transform/transform.hpp
@@ -49,6 +49,6 @@ public:
     void virtual data(Images&) const {}
 #endif
     const ColorRanges virtual *meta(Images&, const ColorRanges *srcRanges) { return new DupColorRanges(srcRanges); }
-    void virtual invData(Images&, uint32_t strideCol=1, uint32_t strideRow=1) const {}
+    void virtual invData(Images&, uint32_t UNUSED(strideCol)=1, uint32_t UNUSED(strideRow)=1) const {}
     bool virtual is_palette_transform() const { return false; }
 };

--- a/src/transform/transform.hpp
+++ b/src/transform/transform.hpp
@@ -49,6 +49,6 @@ public:
     void virtual data(Images&) const {}
 #endif
     const ColorRanges virtual *meta(Images&, const ColorRanges *srcRanges) { return new DupColorRanges(srcRanges); }
-    void virtual invData(Images&, uint32_t UNUSED(strideCol)=1, uint32_t UNUSED(strideRow)=1) const {}
+    void virtual invData(Images&, FLIF_UNUSED(uint32_t strideCol)=1, FLIF_UNUSED(uint32_t strideRow)=1) const {}
     bool virtual is_palette_transform() const { return false; }
 };

--- a/src/transform/ycocg.hpp
+++ b/src/transform/ycocg.hpp
@@ -195,7 +195,7 @@ public:
     }
 
 #ifdef HAS_ENCODER
-    bool process(const ColorRanges *UNUSED(srcRanges), const Images &images) override {
+    bool process(FLIF_UNUSED(const ColorRanges *srcRanges), const Images &images) override {
         if (images[0].palette) return false; // skip YCoCg if the image is already a palette image
         return true;
     }

--- a/src/transform/ycocg.hpp
+++ b/src/transform/ycocg.hpp
@@ -195,7 +195,7 @@ public:
     }
 
 #ifdef HAS_ENCODER
-    bool process(const ColorRanges *srcRanges, const Images &images) override {
+    bool process(const ColorRanges *UNUSED(srcRanges), const Images &images) override {
         if (images[0].palette) return false; // skip YCoCg if the image is already a palette image
         return true;
     }

--- a/src/viewflif.c
+++ b/src/viewflif.c
@@ -5,12 +5,19 @@
  License: Creative Commons CC0 1.0 Universal (Public Domain)
  https://creativecommons.org/publicdomain/zero/1.0/legalcode
 */
-
-
+#if defined(__GNUC__)
+#if defined(__MINGW32__)
+/* Use Gnu-style printf and scanf - see: https://sourceforge.net/p/mingw-w64/wiki2/gnu%20printf/ */
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
+/* allow use of inttypes macros in C++. */
+#define __STDC_FORMAT_MACROS
+#endif
 #include <flif_dec.h>
 #include <stdlib.h>
 #include <stdio.h>
 #if defined(__GNUC__)
+/* Use inttypes.h format macros for greater portability */
 #include <inttypes.h>
 #endif
 #include <SDL.h>
@@ -139,7 +146,7 @@ int do_event(SDL_Event e) {
 bool updateTextures(uint32_t quality, int64_t bytes_read) {
 // Note I would've liked to use inttypes.h PRIi64 but the compiler wouldn't solve it.
     #if defined(__GNUC__)
-    printf("%I64i bytes read, rendering at quality=%.2f%%\n", bytes_read, 0.01*quality);
+    printf("%" PRId64 " bytes read, rendering at quality=%.2f%%\n", bytes_read, 0.01*quality);
     #else
     printf("%lli bytes read, rendering at quality=%.2f%%\n",(long long int) bytes_read, 0.01*quality);
     #endif
@@ -153,7 +160,7 @@ bool updateTextures(uint32_t quality, int64_t bytes_read) {
     if (!window) { printf("Error: Could not create window\n"); return false; }
     char title[100];
     #if defined(__GNUC__)
-    sprintf(title,"FLIF image decoded at %ux%u [read %I64i bytes, quality=%.2f%%]",w,h,(long long int) bytes_read, 0.01*quality);
+    sprintf(title,"FLIF image decoded at %ux%u [read %" PRId64 " bytes, quality=%.2f%%]",w,h,(long long int) bytes_read, 0.01*quality);
     #else
     sprintf(title,"FLIF image decoded at %ux%u [read %lli bytes, quality=%.2f%%]",w,h,(long long int) bytes_read, 0.01*quality);
     #endif


### PR DESCRIPTION
patching file src/config.h
  Add an UNUSED macro to set the unused gcc attribute to fix compiler warnings
patching file src/fileio.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/flif.cpp
  Fix unused parameter warnings with UNUSED macro
patching file src/flif-dec.cpp
  Fix unused parameter warnings with UNUSED macro
patching file src/flif-enc.cpp
  Fix unused parameter warnings with UNUSED macro
patching file src/viewflif.c
  add a copy of the UNUSED macro here so the example will compile without warnings
  fix warnings about an invalid format string.  mingw-w64 uses something different than MS Visual C.
  Fix sign-comparison warnings between uint32_t and int.  Some of that is because the SDL API uses int while FLIF uses uint32_t.
patching file src/image/image.hpp
   Fix unused parameter warnings with UNUSED macro
   Add "falls through" comment to some case statements to eliminate GCC warnings about fallthrough.
patching file src/library/flif_common.h
  __MINGW32__ also requires dllimport/dllexport
patching file src/library/flif-interface-private_common.hpp
  __MINGW32__ also requires dllexport
patching file src/maniac/compound.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/maniac/rac_enc.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/transform/colorbuckets.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/transform/framecombine.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/transform/transform.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/transform/palette_C.hpp
  Fix unused parameter warnings with UNUSED macro
patching file src/transform/ycocg.hpp
  Fix unused parameter warnings with UNUSED macro