### PR TITLE
Fix test-interface compilation error for MSVC x64

### DIFF
--- a/tools/test.c
+++ b/tools/test.c
@@ -33,9 +33,9 @@ https://stackoverflow.com/questions/1546789/clean-code-to-printf-size-t-in-c-or-
    https://code.google.com/archive/p/msinttypes/
   */
 #if defined(_MSC_VER)
-  #define F_I_FILE_SIZE           "%lu"
+  #define F_I_FILE_SIZE           "lu"
   #if defined(_WIN64)
-    #define F_BLOB_SIZE_T         "%I64u"
+    #define F_BLOB_SIZE_T         "I64u"
   #else
     #define F_BLOB_SIZE_T         "PRIu32"
   #endif


### PR DESCRIPTION
Simply removing redundant % to fix the following warnings treated as error:

```
..\..\tools\test.c(329): error C2220: warning treated as error - no 'object' file generated
..\..\tools\test.c(329): warning C4477: 'printf' : format string '%d' requires an argument of type 'int', but variadic argument 1 has type 'const size_t'
..\..\tools\test.c(329): note: consider using '%zd' in the format string
..\..\tools\test.c(329): warning C4477: 'printf' : format string '%d' requires an argument of type 'int', but variadic argument 2 has type 'const size_t'
..\..\tools\test.c(329): note: consider using '%zd' in the format string
```