### PR TITLE
Add related project of libflif-Xcode and SDWebImageFLIFCoder, which is useful for Apple platforms' user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ These will be available on the Release page
 * **[qt-flif-plugin](https://github.com/spillerrec/qt-flif-plugin)** – Enables Qt4 and Qt5 applications to load images in the FLIF image format.
 * **[go-flif](https://github.com/chrisfelesoid/go-flif)** – Go FLIF Library Bindings.
 * **[Phew](https://sveinbjorn.org/phew)** - Image viewer for macOS with QuickLook plugin
+* **[SDWebImageFLIFCoder](https://github.com/SDWebImage/SDWebImage)** - A popular image loading framework [SDWebImage](https://github.com/SDWebImage/SDWebImage)'s coder plugin, supports iOS/macOS/tvOS/watchOS all Apple platforms.
+* **[libflif-Xcode](https://github.com/SDWebImage/libflif-Xcode)** - Xcode project to build libflif on iOS/macOS/tvOS/watchOS all Apple platforms.
 * **[flif-wasm](https://github.com/saschanaz/flif-wasm)** - Node.js-ported FLIF command-line tool.
 * **[node-flif](https://github.com/FLIF-hub/node-flif)** - A Node.JS wrapper that allows you to use JavaScript to interact with the CLI.
 * **[SimplEx FLIF](https://github.com/Atrus09/SimplEx-FLIF)** - A simple and extensive GUI intermediary for the native executables.


### PR DESCRIPTION
Add two libflif related projects.

+ libflif-Xcode

This is a Xcode project configuration, to build libflif libary on **All Apple Platforms**, including iOS/macOS/tvOS/watchOS. As a dynamic framework, use static framework by user's configuration.

This can also include [Carthage](https://github.com/Carthage/Carthage) support. Which is a widelly used Cocoa dependency manager, to manage and build Cocoa/Cocoa Touch library on Apple platforms. It's popular in Cocoa/Cocoa Touch developers.

+ SDWebImageFLIFCoder

This is a coder plugin library, for the favorite Cocoa/Cocoa Touch image loading framework [SDWebImage](https://github.com/SDWebImage/SDWebImage). The framework is used widely cross the world. The coder plugin, can support FLIF images encoding && decoding for user who use this framework. This can also been used as a standalone library when you want High-Level API (Objective-C && Swift) to communicate with Cocoa/Cocoa Touch system framework.