### PR TITLE
Fix for non-power-of-2 maximum pixel values

### DIFF
--- a/src/image/image.hpp
+++ b/src/image/image.hpp
@@ -690,10 +690,17 @@ public:
       width = w;
       height = h;
       minval = min;
+      if (max & (max + 1)) {
+        max |= max >> 1;
+        max |= max >> 2;
+        max |= max >> 4;
+        max |= max >> 8;
+      }
       maxval = max;
       num = p;
       seen_before = -1;
 #ifdef SUPPORT_HDR
+      assert(max<65536);
       if (max < 256) depth=8; else depth=16;
 #else
       assert(max<256);


### PR DESCRIPTION
I've fixed a problem where the FLIF encoder creates malformed files if a non-power-of-2 bit-depth is specified in a PAM file header by forcing the bit depth to a power of 2 in Image::semi_init.