### PR TITLE
Fix testing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,7 +343,9 @@ install(FILES "${FLIF_SRC_DIR}/../LICENSE" "${FLIF_SRC_DIR}/../LICENSE_Apache2" 
 
 enable_testing()
 add_test(NAME libtest COMMAND libtest dummy.flif)
+if(BUILD_STATIC_LIBS)
 add_test(NAME libtest_static COMMAND libtest_static dummy.flif)
+endif(BUILD_STATIC_LIBS)
 
 if(UNIX)
     add_test(NAME roundtrip1 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../tools/test-roundtrip.sh ${CMAKE_CURRENT_SOURCE_DIR}/../tools/2_webp_ll.png 2_webp_ll.flif decoded_2_webp_ll.png)

--- a/tools/test-roundtrip.sh
+++ b/tools/test-roundtrip.sh
@@ -2,10 +2,10 @@
 
 set -ex
 
-FLIF=$1
-IN=$2
-OUTF=$3
-OUTP=$4
+FLIF=./flif
+IN=$1
+OUTF=$2
+OUTP=$3
 
 runtest() {
   local encArgs=$1

--- a/tools/test-roundtrip_anim.sh
+++ b/tools/test-roundtrip_anim.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 # compare $1 (base name without .png extension, could be multiple frames) one by one to the rest of the arguments
-function check {
+check () {
         one=$1*.png
         for c in $one
         do
-                    if [[ $(compare -metric mepp $c $2 null: 2>&1) == "0 (0, 0)" ]]
+                    if [ "$(compare -metric mepp $c $2 null: 2>&1)" = "0 (0, 0)" ]
                     then
                       #echo "OK-compare (identical decoded images)"
                       shift
@@ -21,9 +21,9 @@ function check {
 
 set -ex
 
-FLIF=$1
-IN=$2
-OUTF=$3
+FLIF=./flif
+IN=$1
+OUTF=$2
 
 runtest() {
   local encArgs=$1


### PR DESCRIPTION
The first commit makes usage of `libtest_static` conditional on whether we're building that executable.

The second commit gets rid of unnecessary bash-isms making the scripts usable with a regular sh (such as that found on BSD-systems).

I do not know, why changes to the processing of positional arguments is necessary -- but they are. The scripts are never passed the path to the just-built `flif`-executable.